### PR TITLE
Fixing file descriptor leak

### DIFF
--- a/mppsolar/mppinverter.py
+++ b/mppsolar/mppinverter.py
@@ -332,6 +332,10 @@ class mppInverter:
                 response_line = response_line[:response_line.find(bytes([13])) + 1]
                 break
         log.debug('usb byte_response was: %s', response_line)
+        
+        # close file
+        os.close(usb0)
+        
         command.setByteResponse(response_line)
         return command
 


### PR DESCRIPTION
The file descriptor opened for USB communication needs to be closed at the end of the method.