### PR TITLE
extrapolates real path from device symlink + small bug fix

### DIFF
--- a/mppsolar/__init__.py
+++ b/mppsolar/__init__.py
@@ -1,5 +1,6 @@
 # !/usr/bin/python3
 import logging
+import os
 from argparse import ArgumentParser
 
 from .version import __version__  # noqa: F401
@@ -44,6 +45,9 @@ def main():
         # ch.setLevel(logging.INFO)
 
     log.info('command %s', args.command)
+        
+    #Get real path of device, in case of udev symlink
+    args.device = os.path.realpath(args.device)
     log.info('Serial device used: %s, baud rate: %d', args.device, args.baud)
 
     # mp = mppcommands.mppCommands(args.device, args.baud)

--- a/mppsolar/mppinverter.py
+++ b/mppsolar/mppinverter.py
@@ -117,6 +117,12 @@ def isDirectUsbDevice(serial_device):
     """
     if not serial_device:
         return False
+    if "mpp-solar-serial" in serial_device:
+        log.debug("Device matches mpp-solar-serial")
+        return False
+    if "mpp-solar-direct" in serial_device:
+        log.debug("Device matches mpp-solar-direct")
+        return True
     match = re.search("^.*hidraw\\d$", serial_device)
     if match:
         log.debug("Device matches hidraw regex")
@@ -138,7 +144,7 @@ class mppInverter:
         if not serial_device:
             raise NoDeviceError("A device to communicate by must be supplied, e.g. /dev/ttyUSB0")
         self._baud_rate = baud_rate
-        self._serial_device = serial_device
+        self._serial_device = os.path.realpath(serial_device)
         self._inverter_model = inverter_model
         self._serial_number = None
         self._test_device = isTestDevice(serial_device)

--- a/mppsolar/mppinverter.py
+++ b/mppsolar/mppinverter.py
@@ -117,10 +117,10 @@ def isDirectUsbDevice(serial_device):
     """
     if not serial_device:
         return False
-    if "mpp-solar-serial" in serial_device:
+    if "mppsolar/serial" in serial_device:
         log.debug("Device matches mpp-solar-serial")
         return False
-    if "mpp-solar-direct" in serial_device:
+    if "mppsolar/direct" in serial_device:
         log.debug("Device matches mpp-solar-direct")
         return True
     match = re.search("^.*hidraw\\d$", serial_device)

--- a/mppsolar/mppinverter.py
+++ b/mppsolar/mppinverter.py
@@ -174,7 +174,7 @@ class mppInverter:
             if result:
                 response = result.getResponseDict()
                 # print (byte_response)
-                if response:
+                if "serial_number" in response:
                     self._serial_number = response["serial_number"][0]
         return self._serial_number
 


### PR DESCRIPTION
I am recommending making some changes to reading the device path so that udev created symlinks can be used. With these changes, a udev rule can be made in this fashion
```
ACTION=="add", ATTRS{idVendor}=="<vendor>", ATTRS{idProduct}=="<product>", SYMLINK+="mppsolar/direct/0", MODE="0660", GROUP="plugdev"
```
This allows for a more consistent naming scheme for devices, without actually changing their default nodes.

I have created an installer that, among other things, will create a custom udev rule for selected devices. This will create symlinks in the  form of /dev/mppsolar/<connection_type/<id>. connection_type will be either *direct* or *serial*

If you care to check out the installer, it is at https://github.com/mholgatem/mpp-solar-installer
currently it is cloning my fork of your mpp-solar project because of udev changes