### PR TITLE
Fixed default baud rate setting, add run_commands, separate IO from Protocol (except JKBLE)

### DIFF
--- a/mppsolar/devices/device.py
+++ b/mppsolar/devices/device.py
@@ -65,7 +65,7 @@ class AbstractDevice(metaclass=abc.ABCMeta):
         else:
             return PORT_TYPE_SERIAL
 
-    def set_protocol(self, protocol=None):
+    def set_protocol(self, protocol=None, **kwargs):
         """
         Set the protocol for this device
         """
@@ -95,7 +95,7 @@ class AbstractDevice(metaclass=abc.ABCMeta):
         # TODO: fix protocol instantiate
         self._protocol = self._protocol_class("init_var", proto_keyword="value", second_keyword=123)
 
-    def set_port(self, port=None, baud=2400):
+    def set_port(self, port=None, baud=2400, **kwawgs):
         port_type = self.get_port_type(port)
         if port_type == PORT_TYPE_TEST:
             log.info("Using testio for communications")

--- a/mppsolar/devices/device.py
+++ b/mppsolar/devices/device.py
@@ -95,7 +95,7 @@ class AbstractDevice(metaclass=abc.ABCMeta):
         # TODO: fix protocol instantiate
         self._protocol = self._protocol_class("init_var", proto_keyword="value", second_keyword=123)
 
-    def set_port(self, port=None, baud=None):
+    def set_port(self, port=None, baud=2400):
         port_type = self.get_port_type(port)
         if port_type == PORT_TYPE_TEST:
             log.info("Using testio for communications")
@@ -136,7 +136,7 @@ class AbstractDevice(metaclass=abc.ABCMeta):
         return result
 
     @abc.abstractmethod
-    def run_command(self, command=None, show_raw=False):
+    def run_command(self, command, show_raw=False):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/mppsolar/devices/jk24s.py
+++ b/mppsolar/devices/jk24s.py
@@ -7,9 +7,10 @@ log = logging.getLogger("MPP-Solar")
 
 class jk24s(AbstractDevice):
     def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
         self._name = kwargs["name"]
-        self.set_port(port=kwargs["port"], baud=kwargs["baud"])
-        self.set_protocol(protocol=kwargs["protocol"])
+        self.set_port(**kwargs)
+        self.set_protocol(**kwargs)
         log.debug(f"jk24s __init__ name {self._name}, port {self._port}, protocol {self._protocol}")
         log.debug(f"jk24s __init__ args {args}")
         log.debug(f"jk24s __init__ kwargs {kwargs}")

--- a/mppsolar/devices/mppsolar.py
+++ b/mppsolar/devices/mppsolar.py
@@ -1,6 +1,7 @@
 import logging
 
 from .device import AbstractDevice
+from ..io.testio import TestIO
 
 log = logging.getLogger("MPP-Solar")
 
@@ -43,9 +44,27 @@ class mppsolar(AbstractDevice):
                 ]
             }
 
-        response = self._port.send_and_receive(command, show_raw, self._protocol)
-        log.debug(f"Send and Receive Response {response}")
-        return response
+        # Send command and receive data
+        full_command = self._protocol.get_full_command(command)
+        log.info(f"full command {full_command} for command {command}")
+        # Band-aid solution, can't really segregate TestIO from protocols w/o major rework of TestIO
+        if isinstance(self._port, TestIO):
+            raw_response = self._port.send_and_receive(full_command,
+                                                       self._protocol.get_command_defn(command))
+        else:
+            raw_response = self._port.send_and_receive(full_command)
+        log.debug(f"Send and Receive Response {raw_response}")
+
+        # Handle errors; dict is returned on exception
+        if isinstance(raw_response, dict):
+            return raw_response
+
+        # Decode response
+        decoded_response = self._protocol.decode(raw_response, show_raw, command)
+        log.debug(f"Decoded response {decoded_response}")
+        log.info(f"Decoded response {decoded_response}")
+
+        return decoded_response
 
     def get_status(self, show_raw) -> dict:
         # Run all the commands that are defined as status from the protocol definition

--- a/mppsolar/devices/mppsolar.py
+++ b/mppsolar/devices/mppsolar.py
@@ -7,9 +7,10 @@ log = logging.getLogger("MPP-Solar")
 
 class mppsolar(AbstractDevice):
     def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
         self._name = kwargs["name"]
-        self.set_port(port=kwargs["port"], baud=kwargs["baud"])
-        self.set_protocol(protocol=kwargs["protocol"])
+        self.set_port(**kwargs)
+        self.set_protocol(**kwargs)
         log.debug(
             f"mppsolar __init__ name {self._name}, port {self._port}, protocol {self._protocol}"
         )

--- a/mppsolar/io/baseio.py
+++ b/mppsolar/io/baseio.py
@@ -8,5 +8,5 @@ log = logging.getLogger("MPP-Solar")
 
 class BaseIO(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def send_and_receive(self, command, show_raw, protocol) -> dict:
+    def send_and_receive(self, full_command) -> dict:
         raise NotImplementedError

--- a/mppsolar/io/esp32io.py
+++ b/mppsolar/io/esp32io.py
@@ -17,11 +17,8 @@ class ESP32IO(BaseIO):
         self._serial_port = device_path
         self._serial_baud = serial_baud
 
-    def send_and_receive(self, command, show_raw, protocol) -> dict:
-        log.info(f"ESP32 serial connection: executing {command}")
-        full_command = protocol.get_full_command(command)
-        log.info(f"full command {full_command} for command {command}")
-        command_defn = protocol.get_command_defn(command)
+    def send_and_receive(self, full_command) -> dict:
+        log.info(f"ESP32 serial connection: executing {full_command}")
 
         response_line = None
         uart_no = self._serial_port.lower().split("esp")[1]
@@ -36,16 +33,7 @@ class ESP32IO(BaseIO):
                 time.sleep(0.5)  # give serial port time to receive the data
                 response_line = s.readline()
                 log.debug("esp32 serial response was: %s", response_line)
-                decoded_response = protocol.decode(response_line, show_raw)
-                log.debug(f"Decoded response {decoded_response}")
-                # add command name and description to response
-                decoded_response["_command"] = command
-                if command_defn is not None:
-                    decoded_response["_command_description"] = command_defn[
-                        "description"
-                    ]
-                log.info(f"Decoded response {decoded_response}")
-                return decoded_response
+                return response_line
         except Exception as e:
             log.warning("ESP32 Serial read error: {}".format(e))
         log.info("Command execution failed")

--- a/mppsolar/io/hidrawio.py
+++ b/mppsolar/io/hidrawio.py
@@ -13,18 +13,14 @@ class HIDRawIO(BaseIO):
         # self._fd = os.open(device_path, flags=os.O_RDWR | os.O_NONBLOCK)
         self._device = device_path
 
-    def send_and_receive(self, command, show_raw, protocol) -> dict:
-        full_command = protocol.get_full_command(command)
-        log.info(f"full command {full_command} for command {command}")
-        command_defn = protocol.get_command_defn(command)
-
+    def send_and_receive(self, full_command) -> dict:
         response_line = bytes()
         usb0 = None
         try:
             usb0 = os.open(self._device, os.O_RDWR | os.O_NONBLOCK)
         except Exception as e:
             log.debug("USB open error: {}".format(e))
-            return command
+            return {"ERROR": ["USB open error: {}".format(e), ""]}
         # Send the command to the open usb connection
         to_send = full_command
         try:
@@ -70,12 +66,4 @@ class HIDRawIO(BaseIO):
                 break
         log.debug("usb response was: %s", response_line)
         os.close(usb0)
-        decoded_response = protocol.decode(response_line, show_raw)
-        # _response = response.decode('utf-8')
-        log.debug(f"Decoded response {decoded_response}")
-        # add command name and description to response
-        decoded_response["_command"] = command
-        if command_defn is not None:
-            decoded_response["_command_description"] = command_defn["description"]
-        log.info(f"Decoded response {decoded_response}")
-        return decoded_response
+        return response_line

--- a/mppsolar/io/jkbleio.py
+++ b/mppsolar/io/jkbleio.py
@@ -20,7 +20,7 @@ class JkBleIO(BaseIO):
             "55aaeb9002ff5b566240e34e62406e6a62404a506240acd7624011d26240bddd62409ad1624044c86240cedc6240ccc7624079e1624057dc624073a262405f80624088c46240000000000000000000000000000000000000000000000000000000000000000013315c3d0636143d26e0113d8021f03c1153363d8980123d7e7c033dac41233d1ad83c3d9d6f4f3d8eb51e3d6a2c293deb28653d189c523da3724e3deb94493d9ab2c23d00000000000000000000000000000000000000000000000000000000000000001aad62400084053c00000000ffff00000b000000000000000000000000000036a3554c40000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000be0b54001456a43fb876a43f00a2"
         )
 
-    def send_and_receive(self, command, show_raw, protocol) -> dict:
+    def send_and_receive(self, command, show_raw=False, protocol=None) -> dict:
         full_command = protocol.get_full_command(command)
         log.info(f"full command {full_command} for command {command}")
         # Send the full command via the communications port
@@ -40,12 +40,8 @@ class JkBleIO(BaseIO):
             response = None
         # End of BLE device connection
         log.debug(f"Raw response {response}")
-        decoded_response = protocol.decode(response, show_raw)
+        decoded_response = protocol.decode(response, show_raw, command)
         log.debug(f"Decoded response {decoded_response}")
-        # add command name and description to response
-        decoded_response["_command"] = command
-        if command_defn is not None:
-            decoded_response["_command_description"] = command_defn["description"]
         log.info(f"Decoded response {decoded_response}")
         return decoded_response
 

--- a/mppsolar/io/serialio.py
+++ b/mppsolar/io/serialio.py
@@ -12,11 +12,7 @@ class SerialIO(BaseIO):
         self._serial_port = device_path
         self._serial_baud = serial_baud
 
-    def send_and_receive(self, command, show_raw, protocol) -> dict:
-        full_command = protocol.get_full_command(command)
-        log.info(f"full command {full_command} for command {command}")
-        command_defn = protocol.get_command_defn(command)
-
+    def send_and_receive(self, full_command) -> dict:
         response_line = None
         log.debug(f"port {self._serial_port}, baudrate {self._serial_baud}")
         try:
@@ -30,14 +26,7 @@ class SerialIO(BaseIO):
                 time.sleep(0.1)  # give serial port time to receive the data
                 response_line = s.read_until(expected=b"\r")
                 log.debug("serial response was: %s", response_line)
-                decoded_response = protocol.decode(response_line, show_raw)
-                log.debug(f"Decoded response {decoded_response}")
-                # add command name and description to response
-                decoded_response["_command"] = command
-                if command_defn is not None:
-                    decoded_response["_command_description"] = command_defn["description"]
-                log.info(f"Decoded response {decoded_response}")
-                return decoded_response
+                return response_line
         except Exception as e:
             log.warning(f"Serial read error: {e}")
         log.info("Command execution failed")

--- a/mppsolar/io/serialio.py
+++ b/mppsolar/io/serialio.py
@@ -10,10 +10,7 @@ log = logging.getLogger("MPP-Solar")
 class SerialIO(BaseIO):
     def __init__(self, device_path, serial_baud) -> None:
         self._serial_port = device_path
-        if serial_baud is None:
-            self._serial_baud = 2400
-        else:
-            self._serial_baud = serial_baud
+        self._serial_baud = serial_baud
 
     def send_and_receive(self, command, show_raw, protocol) -> dict:
         full_command = protocol.get_full_command(command)

--- a/mppsolar/io/testio.py
+++ b/mppsolar/io/testio.py
@@ -12,11 +12,7 @@ class TestIO(BaseIO):
         self._test_data = b"(230.0 50.0 0030 42.0 54.0 56.4 46.0 60 0 0 2 0 0 0 0 0 1 1 0 0 1 0 54.0 0 1 000\x9E\x60\r"
         self._counter = 0
 
-    def send_and_receive(self, command, show_raw, protocol) -> dict:
-        full_command = protocol.get_full_command(command)
-        log.info(f"full command {full_command} for command {command}")
-        # Send the full command via the communications port
-        command_defn = protocol.get_command_defn(command)
+    def send_and_receive(self, full_command, command_defn=None) -> dict:
         if command_defn is not None:
             self._test_data = command_defn["test_responses"][
                 random.randrange(len(command_defn["test_responses"]))
@@ -24,12 +20,4 @@ class TestIO(BaseIO):
         response = self._test_data
         # response = b"(PI30\x9a\x0b\r"
         log.debug(f"Raw response {response}")
-        decoded_response = protocol.decode(response, show_raw)
-        # _response = response.decode('utf-8')
-        log.debug(f"Decoded response {decoded_response}")
-        # add command name and description to response
-        decoded_response["_command"] = command
-        if command_defn is not None:
-            decoded_response["_command_description"] = command_defn["description"]
-        log.info(f"Decoded response {decoded_response}")
-        return decoded_response
+        return response


### PR DESCRIPTION
I (mostly) separated IO from protocol since it was (getting) difficult to read through the code. Now IO exclusively sends and returns raw bytes, decoding is done from `devices`. 

I'm not too familiar with JKBLE stuff so I left that mostly untouched, it seems to be rather 'entangled' with the JK protocol file so I didn't know how to deal with it. Perhaps you could look into that? There's a band-aid `isinstance` check for jkble io to use the 'old' method

Also, I wanted to change 
https://github.com/Northbadge/mpp-solar/blob/fa1e552691669a66632ecd3fb5d18b1cdd2cebfe/mppsolar/protocols/protocol.py#L104-L107
to "WARNING" instead of "ERROR"; Your thoughts on that?

