### PR TITLE
Handle unexpected / unknown flags

### DIFF
--- a/mppsolar/protocols/protocol.py
+++ b/mppsolar/protocols/protocol.py
@@ -170,7 +170,10 @@ class AbstractProtocol(metaclass=abc.ABCMeta):
                     else:
                         # output[resp_format[2][item]['name']] = status
                         # _key = "{}".format(resp_format[2][item]["name"]).lower().replace(" ", "_")
-                        _key = resp_format[2][item]["name"]
+                        if resp_format[2].get(item, None):
+                            _key = resp_format[2][item]["name"]
+                        else:
+                            _key = "unknown_{}".format(item)
                         msgs[_key] = [status, ""]
                 # msgs[key] = [output, '']
             elif command_defn["type"] == "SETTER":


### PR DESCRIPTION
The PIP-3048LV-MK returns two unknown QFLAGS which caused the code
in protocol.py to error out with a key error.

This change handles the error condition by checking for the key
in the protocol definition and if it is not found using a fallback
key ("unknown_" followed by the character that represents the flag
in the raw protocol.)