### PR TITLE
Send commands to mpp-solar service via broker

### DIFF
--- a/docs/service/receive-commands.conf
+++ b/docs/service/receive-commands.conf
@@ -1,0 +1,32 @@
+[SETUP]
+#Pause will now account for the time it takes to run the commands
+pause=5
+mqtt_broker=localhost
+
+#Runs no commands, it waits for requests on the commands_topic
+[Schedule_requests]
+port=/dev/hidraw0
+protocol=PI30
+command=
+commands_topic=green_grid/ross_proto_01/command
+outputs=json_mqtt
+pause_loops=0
+mqtt_output_topic=green_grid/ross_proto_01/requests/
+
+#Gets the stats every other loop (10 seconds)
+[Schedule_stats]
+port=/dev/hidraw0
+protocol=PI30
+command=QPIGS
+outputs=json_mqtt
+pause_loops=1
+mqtt_output_topic=green_grid/ross_proto_01/
+
+#Getings the device settings every 6 loops (30 seconds)
+[Schedule_settings]
+port=/dev/hidraw0
+protocol=PI30
+command=QPIRI
+outputs=json_mqtt
+pause_loops=5
+mqtt_output_topic=green_grid/ross_proto_01/

--- a/mppsolar/__init__.py
+++ b/mppsolar/__init__.py
@@ -212,10 +212,10 @@ def main():
     if args.daemon:
         import time
 
-        import systemd.daemon
+        from systemd.daemon import notify, Notification
 
         # Tell systemd that our service is ready
-        systemd.daemon.notify("READY=1")
+        notify(Notification.READY)
         print("Service Initializing ...")
         # set some default-defaults
         pause = 60
@@ -259,6 +259,7 @@ def main():
             porttype = config[section].get("porttype", fallback=None)
             filter = config[section].get("filter", fallback=None)
             excl_filter = config[section].get("exclfilter", fallback=None)
+            pause_loops = config[section].get("pause_loops", fallback=0)
             #
             device_class = get_device_class(_type)
             log.debug(f"device_class {device_class}")
@@ -274,6 +275,7 @@ def main():
                 # mqtt_port=mqtt_port,
                 # mqtt_user=mqtt_user,
                 # mqtt_pass=mqtt_pass,
+                pause_loops=pause_loops,
             )
             # build array of commands
             commands = _command.split(",")
@@ -359,7 +361,7 @@ def main():
             # for item in mppUtilArray:
             # Tell systemd watchdog we are still alive
             if args.daemon:
-                systemd.daemon.notify("WATCHDOG=1")
+                notify(Notification.WATCHDOG)
                 print(
                     f"Getting results from device: {_device} for command: {_command}, tag: {_tag}, outputs: {_outputs}"
                 )
@@ -389,7 +391,7 @@ def main():
                 )
                 # Tell systemd watchdog we are still alive
         if args.daemon:
-            systemd.daemon.notify("WATCHDOG=1")
+            notify(Notification.WATCHDOG)
             print(f"Sleeping for {pause} sec")
             time.sleep(pause)
         else:

--- a/mppsolar/__init__.py
+++ b/mppsolar/__init__.py
@@ -373,7 +373,7 @@ def main():
                     f"Getting results from device: {device}"
                 )
             for command in device.get_commands():
-                results = device.run_command(command)
+                results = device.run_command(command["command"])
                 log.debug(f"results: {results}")
                 # send to output processor(s)
                 outputs = get_outputs(device.outputs)
@@ -384,8 +384,8 @@ def main():
                     log.debug(f"Using output filter: {filter}")
                     op.output(
                         data=results,
-                        tag=command, #not sure how tags are supposed to work
-                        mqtt_topic=device.get_mqtt_output_topic(),
+                        tag=command["command"], #not sure how tags are supposed to work
+                        mqtt_topic=command["topic"],
                         mqtt_broker=mqtt_broker,
                         filter=device.get_filter(),
                         excl_filter=device.get_excl_filter(),

--- a/mppsolar/__init__.py
+++ b/mppsolar/__init__.py
@@ -253,6 +253,7 @@ def main():
             port = config[section].get("port", fallback="/dev/ttyUSB0")
             baud = config[section].get("baud", fallback=2400)
             _command = config[section].get("command")
+            mqtt_output_topic = config[section].get("mqtt_output_topic")
             tag = config[section].get("tag")
             outputs = config[section].get("outputs", fallback="screen")
             porttype = config[section].get("porttype", fallback=None)
@@ -279,6 +280,7 @@ def main():
                 filter=filter,
                 excl_filter=excl_filter,
                 mqtt_broker=mqtt_broker, #not used?
+                mqtt_output_topic=mqtt_output_topic,
                 commands_topic=commands_topic,
                 pause_loops=pause_loops,
             )
@@ -383,9 +385,10 @@ def main():
                     op.output(
                         data=results,
                         tag=command, #not sure how tags are supposed to work
+                        mqtt_topic=device.get_mqtt_output_topic(),
                         mqtt_broker=mqtt_broker,
-                        filter=device.filter,
-                        excl_filter=device.excl_filter,
+                        filter=device.get_filter(),
+                        excl_filter=device.get_excl_filter(),
                         keep_case=keep_case,
                     )
 
@@ -394,7 +397,9 @@ def main():
         if args.daemon:
             notify(Notification.WATCHDOG)
             print(f"Commands took {runTime} seconds to complete. Sleeping for {pause-runTime} sec")
-            time.sleep(pause-runTime)
+            sleepTime = pause-runTime
+            if sleepTime > 0:
+                time.sleep(pause-runTime)
         else:
             # Dont loop unless running as daemon
             log.debug(f"Commands took {runTime} seconds to complete. Not daemon, so not looping")

--- a/mppsolar/devices/device.py
+++ b/mppsolar/devices/device.py
@@ -35,240 +35,33 @@ class AbstractDevice(ABC):
         self._name = get_kwargs(kwargs, "name")
         self._port = get_port(**kwargs)
         self._protocol = get_protocol(get_kwargs(kwargs, "protocol"))
-        log.debug(f"__init__ name {self._name}, port {self._port}, protocol {self._protocol}")
+        pause_loops = get_kwargs(kwargs, "pause_loops")
+        if pause_loops is None:
+            self._pause_loops = 0
+        else:
+            self._pause_loops = int(pause_loops)
+        self._current_loop = 0
+        log.debug(f"__init__ name {self._name}, port {self._port}, protocol {self._protocol}, loops {self._pause_loops}")
 
     def __str__(self):
         """
         Build a printable representation of this class
         """
-        return f"{self._classname} device - name: {self._name}, port: {self._port}, protocol: {self._protocol}"
+        return f"{self._classname} device - name: {self._name}, port: {self._port}, protocol: {self._protocol}, pause_loops: {self._pause_loops}"
 
-    # def get_port_type(self, port):
-    #     if port is None:
-    #         return PORT_TYPE_UNKNOWN
-
-    #     port = port.lower()
-    #     # check for test type port
-    #     if "test" in port:
-    #         log.debug("port matches test")
-    #         return PORT_TYPE_TEST
-    #     # mqtt
-    #     elif "mqtt" in port:
-    #         log.debug("port matches mqtt")
-    #         return PORT_TYPE_MQTT
-    #     # USB type ports
-    #     elif "hidraw" in port:
-    #         log.debug("port matches hidraw")
-    #         return PORT_TYPE_USB
-    #     elif "mppsolar" in port:
-    #         log.debug("port matches mppsolar")
-    #         return PORT_TYPE_USB
-    #     # ESP type ports
-    #     elif "esp" in port:
-    #         log.debug("port matches esp")
-    #         return PORT_TYPE_ESP32
-    #     # JKBLE type ports
-    #     elif ":" in port:
-    #         # all mac addresses currently return as JKBLE
-    #         log.debug("port matches jkble ':'")
-    #         return PORT_TYPE_JKBLE
-    #     elif "jkble" in port:
-    #         log.debug("port matches jkble")
-    #         return PORT_TYPE_JKBLE
-    #     elif "daly" in port:
-    #         log.debug("port matches daly")
-    #         return PORT_TYPE_DALYSERIAL
-    #     elif "vserial" in port:
-    #         log.debug("port matches vserial")
-    #         return PORT_TYPE_VSERIAL
-    #     elif "serial" in port:
-    #         log.debug("port matches serial")
-    #         return PORT_TYPE_SERIAL
-    #     elif "ttyusb" in port:
-    #         log.debug("port matches ttyusb")
-    #         return PORT_TYPE_SERIAL
-    #     else:
-    #         return PORT_TYPE_UNKNOWN
-
-    # def set_protocol(self, *args, **kwargs):
-    #     """
-    #     Set the protocol for this device
-    #     """
-    #     protocol = get_kwargs(kwargs, "protocol")
-    #     log.debug(f"Protocol {protocol}")
-    #     if protocol is None:
-    #         self._protocol = None
-    #         self._protocol_class = None
-    #         return
-    #     protocol_id = protocol.lower()
-    #     # Try to import the protocol module with the supplied name (may not exist)
-    #     try:
-    #         proto_module = importlib.import_module("mppsolar.protocols." + protocol_id, ".")
-    #     except ModuleNotFoundError:
-    #         log.error(f"No module found for protocol {protocol_id}")
-    #         self._protocol = None
-    #         self._protocol_class = None
-    #         return
-    #     # Find the protocol class - classname must be the same as the protocol_id
-    #     try:
-    #         self._protocol_class = getattr(proto_module, protocol_id)
-    #     except AttributeError:
-    #         log.error(f"Module {proto_module} has no attribute {protocol_id}")
-    #         self._protocol = None
-    #         self._protocol_class = None
-    #         return
-    #     # Instantiate the class
-    #     # TODO: fix protocol instantiate
-    #     self._protocol = self._protocol_class(
-    #         "init_var", proto_keyword="value", second_keyword=123
-    #     )
-
-    # def set_port(self, *args, **kwargs):
-    #     port = get_kwargs(kwargs, "port")
-    #     baud = get_kwargs(kwargs, "baud", 2400)
-    #     porttype = get_kwargs(kwargs, "porttype")
-
-    #     if porttype:
-    #         log.info(f"Port overide - using port '{porttype}'")
-    #         port_type = self.get_port_type(porttype)
-    #     else:
-    #         port_type = self.get_port_type(port)
-
-    #     if port_type == PORT_TYPE_TEST:
-    #         log.info("Using testio for communications")
-    #         from mppsolar.io.testio import TestIO
-
-    #         self._port = TestIO(device_path=port)
-
-    #     elif port_type == PORT_TYPE_USB:
-    #         log.info("Using hidrawio for communications")
-    #         from mppsolar.io.hidrawio import HIDRawIO
-
-    #         self._port = HIDRawIO(device_path=port)
-
-    #     elif port_type == PORT_TYPE_ESP32:
-    #         log.info("Using esp32io for communications")
-    #         from mppsolar.io.esp32io import ESP32IO
-
-    #         self._port = ESP32IO(device_path=port)
-
-    #     elif port_type == PORT_TYPE_JKBLE:
-    #         log.info("Using jkbleio for communications")
-    #         from mppsolar.io.jkbleio import JkBleIO
-
-    #         self._port = JkBleIO(device_path=port)
-
-    #     elif port_type == PORT_TYPE_SERIAL:
-    #         log.info("Using serialio for communications")
-    #         from mppsolar.io.serialio import SerialIO
-
-    #         self._port = SerialIO(device_path=port, serial_baud=baud)
-
-    #     elif port_type == PORT_TYPE_DALYSERIAL:
-    #         log.info("Using dalyserialio for communications")
-    #         from mppsolar.io.dalyserialio import DalySerialIO
-
-    #         self._port = DalySerialIO(device_path=port, serial_baud=baud)
-
-    #     elif port_type == PORT_TYPE_VSERIAL:
-    #         log.info("Using vserialio for communications")
-    #         from mppsolar.io.vserialio import VSerialIO
-
-    #         self._port = VSerialIO(device_path=port, serial_baud=baud, records=30)
-
-    #     elif port_type == PORT_TYPE_MQTT:
-
-    #         mqtt_broker = get_kwargs(kwargs, "mqtt_broker", "localhost")
-    #         # mqtt_port = get_kwargs(kwargs, "mqtt_port", 1883)
-    #         # mqtt_user = get_kwargs(kwargs, "mqtt_user")
-    #         # mqtt_pass = get_kwargs(kwargs, "mqtt_pass")
-    #         log.info(f"Using mqttio for communications broker {mqtt_broker}")
-
-    #         from mppsolar.io.mqttio import MqttIO
-
-    #         self._port = MqttIO(
-    #             client_id=self._name,
-    #             mqtt_broker=mqtt_broker,
-    #             # mqtt_port=mqtt_port,
-    #             # mqtt_user=mqtt_user,
-    #             # mqtt_pass=mqtt_pass,
-    #         )
-
-    #     else:
-    #         self._port = None
-
-    # def list_commands(self):
-    #     # print(f"{'Parameter':<30}\t{'Value':<15} Unit")
-    #     if self._protocol is None:
-    #         log.error("Attempted to list commands with no protocol defined")
-    #         return {"ERROR": ["Attempted to list commands with no protocol defined", ""]}
-    #     result = {}
-    #     result["_command"] = "command help"
-    #     result[
-    #         "_command_description"
-    #     ] = f"List available commands for protocol {str(self._protocol._protocol_id, 'utf-8')}"
-    #     for command in self._protocol.COMMANDS:
-    #         if "help" in self._protocol.COMMANDS[command]:
-    #             info = (
-    #                 self._protocol.COMMANDS[command]["description"]
-    #                 + self._protocol.COMMANDS[command]["help"]
-    #             )
-    #         else:
-    #             info = self._protocol.COMMANDS[command]["description"]
-    #         result[command] = [info, ""]
-    #     return result
-
-    # def list_outputs(self):
-    #     import pkgutil
-
-    #     print("device list outouts")
-    #     pkgpath = __file__
-    #     pkgpath = pkgpath[: pkgpath.rfind("/")]
-    #     pkgpath += "/../outputs"
-    #     # print(pkgpath)
-    #     result = {}
-    #     result["_command"] = "outputs help"
-    #     result["_command_description"] = "List available output modules"
-    #     for _, name, _ in pkgutil.iter_modules([pkgpath]):
-    #         # print(name)
-    #         _module_class = importlib.import_module("mppsolar.outputs." + name, ".")
-    #         _module = getattr(_module_class, name)
-    #         # print(_module())
-    #         result[name] = (str(_module()), "", "")
-    #     # print(result)
-    #     return result
-
-    # def run_commands(self, commands) -> dict:
-    #     """
-    #     Run multiple commands sequentially
-    #     :param commands: List of commands to run, either with or without an alias.
-    #     If an alias is provided, it will be substituted in place of cmd name in the returned dict
-    #     Additional elements in the tuple will be passed to run_command as ordered
-    #     Example: ['QPIWS', ...] or [('QPIWS', 'ALIAS'), ...] or [('QPIWS', 'ALIAS', True), ...] or mix and match
-    #     :return: Dictionary of responses
-    #     """
-    #     responses = {}
-    #     for i, command in enumerate(commands):
-    #         if isinstance(command, str):
-    #             responses[command] = self.run_command(command)
-    #         elif isinstance(command, tuple) and len(command) > 0:
-    #             if len(command) == 1:  # Treat as string
-    #                 responses[command[0]] = self.run_command(command[0])
-    #             elif len(command) == 2:
-    #                 responses[command[1]] = self.run_command(command[0])
-    #             else:
-    #                 responses[command[1]] = self.run_command(command[0], *command[2:])
-    #         else:
-    #             responses["Command {:d}".format(i)] = {
-    #                 "ERROR": ["Unknown command format", "(Indexed from 0)"]
-    #             }
-    #     return responses
 
     def run_command(self, command) -> dict:
         """
         generic method for running a 'raw' command
         """
         log.info(f"Running command {command}")
+
+        if self._current_loop < self._pause_loops:
+            log.debug(f"on loop {self._current_loop} of {self._pause_loops} not running")
+            self._current_loop += 1
+            return None
+        else:
+            self._current_loop = 0;
 
         if self._protocol is None:
             log.error("Attempted to run command with no protocol defined")

--- a/mppsolar/outputs/json_mqtt.py
+++ b/mppsolar/outputs/json_mqtt.py
@@ -20,11 +20,8 @@ class json_mqtt(mqtt):
         data = get_kwargs(kwargs, "data")
         tag = get_kwargs(kwargs, "tag")
         keep_case = get_kwargs(kwargs, "keep_case")
-        mqtt_broker = get_kwargs(kwargs, "mqtt_broker")
-        if mqtt_broker is not None:
-            topic = mqtt_broker.results_topic
-        else:
-            topic = get_kwargs(kwargs, "mqtt_topic", default="mpp-solar")
+
+        topic = get_kwargs(kwargs, "mqtt_topic", default="mpp-solar/")
         filter = get_kwargs(kwargs, "filter")
         if filter is not None:
             filter = re.compile(filter)
@@ -43,6 +40,8 @@ class json_mqtt(mqtt):
         data.pop("raw_response", None)
         if tag is None:
             tag = cmd
+        topic = topic + tag
+
         output = {}
         # Loop through responses
         for key in data:

--- a/mppsolar/protocols/pi30.py
+++ b/mppsolar/protocols/pi30.py
@@ -484,6 +484,7 @@ COMMANDS = {
                     "B": "Battery",
                     "F": "Fault",
                     "H": "Power saving",
+                    "E": "Eco"
                 },
             ]
         ],

--- a/mppsolar/version.py
+++ b/mppsolar/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.9.03"
-__version_comment__ = "add results_topic to json_mqtt output"
+__version__ = "0.9.04"
+__version_comment__ = "Adding config for complex scheduling"


### PR DESCRIPTION
This is my first pull request to an open source project and my first taste of python so please excuse any major missteps.

My main goals were to add a mechanism to run commands at different rates and send commands to be run by the service. When I tried to execute commands outside of the service they often collided and failed. 

To change the rate commands are run I added the pause_loops option int he config file, it's the number of loops to skip before running.

To listen for commands you can include a commands_topic and any strings send will be included in the commands run. I have a planned improvement so the commands sent also includes a response topic to make it easier for two way communication.

I also refactored the main method a bit to make it a bit more object oriented. Further improvement I think would help would be separating the concepts of device, schedule and command. Device defines the port and protocol. Command defines command and output. Schedule will define which commands are running on which devices and how often.

I have not done extensive testing on features I am not using. I noticed tags didn't work with the json_mqtt output and I may have broken them for other outputs. I didn't test filters.