### PR TITLE
Add Protocol Options to PI18 (MPPSolar 5048 Hybrid V2)

### DIFF
--- a/mppsolar/protocols/pi18.py
+++ b/mppsolar/protocols/pi18.py
@@ -8,62 +8,133 @@ from .protocol_helpers import crcPI as crc
 log = logging.getLogger("pi18")
 
 COMMANDS = {
+    ### QUERY ###
     "ET": {
         "name": "ET",
+        "prefix": "^P005",
         "description": "Total Generated Energy query",
         "help": " -- Query total generated energy",
         "type": "QUERY",
-        "response": [["int", "Total generated energy", "Wh"]],
+        "response": [
+            ["int", "Total generated energy", "Wh"]
+        ],
         "test_responses": [
             b"",
         ],
     },
+    "EY": {
+        "name": "EY",
+        "prefix": "^P009",
+        "description": "Query generated energy of year",
+        "help": " -- queries generated energy for the year YYYY from the Inverter",
+        "type": "QUERY",
+        "response": [
+            ["int", "Year generated energy", "Wh"]
+        ],
+        "test_responses": [
+            b"",
+        ],
+        "regex": "EY(\\d\\d\\d\\d)$",
+    },
+    "ID": {
+        "name": "ID",
+        "prefix": "^P005",
+        "description": "Device Serial Number inquiry",
+        "help": " -- queries the device serial number",
+        "type": "QUERY",
+        "response": [["string",	"Serial Number", ""]],
+        "test_responses": [
+            b"^D02514012345678901234567\r",
+        ],
+    },
+    "VFW": {
+        "name": "VFW",
+        "prefix": "^P006",
+        "description": "Device CPU version inquiry",
+        "help": " -- queries the CPU version",
+        "type": "QUERY",
+        "response": [
+            ["int", 	"Main CPU Version", 			""],
+            ["int", 	"Slave 1 CPU Version", 			""],
+            ["int", 	"Slave 2 CPU Version", 			""],
+        ],
+        "test_responses": [
+            b"^^D02005220,00000,00000\r",
+        ],
+    },
+
+    "PIRI": {
+        "name": "PIRI",
+        "prefix": "^P007",
+        "description": "Device rated information",
+        "help": " -- queries rated information",
+        "type": "QUERY",
+        "response": [
+            ["10int",	"AC input rated voltage", 		"V"],
+            ["10int", 	"AC input rated current", 		"A"],
+            ["10int", 	"AC output rated voltage", 		"V"],
+            ["10int", 	"AC output rated frequency", 		"Hz"],
+            ["10int", 	"AC output rated current", 		"A"],
+            ["int", 	"AC output rating apparent power", 	"VA"],
+            ["int", 	"AC output rating active power", 	"W"],
+            ["10int", 	"Battery rated voltage", 		"V"],
+            ["10int", 	"Battery re-charge voltage", 		"V"],
+            ["10int", 	"Battery re-discharge voltage", 	"V"],
+            ["10int", 	"Battery under voltage", 		"V"],
+            ["10int", 	"Battery bulk voltage", 		"V"],
+            ["10int", 	"Battery float voltage", 		"V"],
+            ["option",	"Battery type",				[ "AGM", "Flooded", "User" ]],
+            ["int", 	"Max AC charging current",		"A"],
+            ["int", 	"Max charging current",			"A"],
+            ["option",	"Input voltage rang",			[ "Appliance", "UPS" ]],
+            ["option",	"Output source priority",		[ "Solar-Utility-Battery", "Solar-Battery-Utility" ]],
+            ["option",	"Charger source priority",		[ "Solar First", "Solar and Utility", "Only Solar" ]],
+            ["int", 	"Parallel max num",			""],
+            ["option",	"Machine type",				[ "Off-Grid", "Grid-Tie" ]],
+            ["option",	"Topology",				[ "transformerless", "transformer" ]],
+            ["option",	"Output model setting",			[ "Single module", "parallel output", "Phase 1 of three phase output", "Phase 2 of three phase output", "Phase 3 of three phase output" ]],
+            ["option",	"Solar power priority",			[ "Battery-Load-Utiliy + AC Charger", "Load-Battery-Utiliy" ]],
+            ["int", 	"MPPT strings",				""],
+        ],
+        "test_responses": [
+            b"^D0882300,217,2300,500,217,5000,5000,480,500,540,450,552,545,2,10,060,1,1,1,9,1,0,0,0,1,00\r",
+        ],
+    },
     "GS": {
         "name": "GS",
+        "prefix": "^P005",
         "description": "General status query",
         "help": " -- Query general status information",
         "type": "QUERY",
         "response": [
-            ["10int", "Grid voltage", "V"],
-            ["10int", "Grid frequency", "Hz"],
-            ["10int", "AC output voltage", "V"],
-            ["10int", "AC output frequency", "Hz"],
-            ["int", "AC output apparent power", "VA"],
-            ["int", "AC output active power", "W"],
-            ["int", "Output load percent", "%"],
-            ["10int", "Battery voltage", "V"],
-            ["10int", "Battery voltage from SCC", "V"],
-            ["10int", "Battery voltage from SCC2", "V"],
-            ["int", "Battery discharge current", "A"],
-            ["int", "Battery charging current", "A"],
-            ["int", "Battery capacity", "%"],
-            ["int", "Inverter heat sink temperature", "°C"],
-            ["int", "MPPT1 charger temperature", "°C"],
-            ["int", "MPPT2 charger temperature", "°C"],
-            ["int", "PV1 Input power", "W"],
-            ["int", "PV2 Input power", "W"],
-            ["10int", "PV1 Input voltage", "V"],
-            ["10int", "PV2 Input voltage", "V"],
-            [
-                "option",
-                "Setting value configuration state",
-                ["Nothing changed", "Something changed"],
-            ],
-            [
-                "option",
-                "MPPT1 charger status",
-                ["abnormal", "normal but not charged", "charging"],
-            ],
-            [
-                "option",
-                "MPPT2 charger status",
-                ["abnormal", "normal but not charged", "charging"],
-            ],
-            ["option", "Load connection", ["disconnect", "connect"]],
-            ["option", "Battery power direction", ["donothing", "charge", "discharge"]],
-            ["option", "DC/AC power direction", ["donothing", "AC-DC", "DC-AC"]],
-            ["option", "Line power direction", ["donothing", "input", "output"]],
-            ["int", "Local parallel ID", ""],
+            ["10int",	"Grid voltage",				"V"],
+            ["10int",	"Grid frequency",			"Hz"],
+            ["10int",	"AC output voltage",			"V"],
+            ["10int",	"AC output frequency",			"Hz"],
+            ["int",	"AC output apparent power",		"VA"],
+            ["int",	"AC output active power",		"W"],
+            ["int",	"Output load percent",			"%"],
+            ["10int",	"Battery voltage",			"V"],
+            ["10int",	"Battery voltage from SCC",		"V"],
+            ["10int",	"Battery voltage from SCC2",		"V"],
+            ["int",	"Battery discharge current",		"A"],
+            ["int",	"Battery charging current",		"A"],
+            ["int",	"Battery capacity",			"%"],
+            ["int",	"Inverter heat sink temperature",	"°C"],
+            ["int",	"MPPT1 charger temperature",		"°C"],
+            ["int",	"MPPT2 charger temperature",		"°C"],
+            ["int",	"PV1 Input power",			"W"],
+            ["int",	"PV2 Input power",			"W"],
+            ["10int",	"PV1 Input voltage",			"V"],
+            ["10int",	"PV2 Input voltage",			"V"],
+            ["option",	"Setting value configuration state",	[ "Nothing changed", "Something changed" ]],
+            ["option",	"MPPT1 charger status",			[ "abnormal", "normal but not charged", "charging" ]],
+            ["option",	"MPPT2 charger status",			[ "abnormal", "normal but not charged", "charging" ]],
+            ["option",	"Load connection",			[ "disconnect", "connect" ]],
+            ["option",	"Battery power direction",		[ "donothing", "charge", "discharge" ]],
+            ["option",	"DC/AC power direction",		[ "donothing", "AC-DC", "DC-AC" ]],
+            ["option",	"Line power direction",			[ "donothing", "input", "output" ]],
+            ["int", 	"Local parallel ID",			""],
         ],
         "test_responses": [
             b"D1062232,499,2232,499,0971,0710,019,008,000,000,000,000,000,044,000,000,0520,0000,1941,0000,0,2,0,1,0,2,1,0\x09\x7b\r",
@@ -72,22 +143,104 @@ COMMANDS = {
     },
     "MOD": {
         "name": "MOD",
+        "prefix": "^P006",
         "description": "Working mode query",
         "help": " -- Query the working mode",
         "type": "QUERY",
         "response": [
-            [
-                "option",
-                "Working mode",
-                [
-                    "Power on mode",
-                    "Standby mode",
-                    "Bypass mode",
-                    "Battery mode",
-                    "Fault mode",
-                    "Hybrid mode(Line mode, Grid mode)",
-                ],
-            ]
+            ["option",	"Working mode",				[ "Power on mode", "Standby mode", "Bypass mode", "Battery mode", "Fault mode", "Hybrid mode(Line mode, Grid mode)" ]],
+        ],
+        "test_responses": [
+            b"",
+        ],
+    },
+
+#    "FWS": {
+#        "name": "FWS",
+#        "prefix": "^P005",
+#        "description": "fault and warning status",
+#        "help": " -- Query fault and warning status",
+#        "type": "QUERY",
+#        "response": [
+#            [
+#            ]
+#        ],
+#        "test_responses": [
+#            b"",
+#        ],
+#    },
+
+    "FLAG": {
+        "name": "FLAG",
+        "prefix": "^P007",
+        "description": "Query enable/disable flag status",
+        "help": " -- queries enable/disable flag status from the Inverter",
+        "type": "QUERY",
+        "response": [
+            ["option",	"Buzzer beep",				[ "Disabled", "Enabled" ]],
+            ["option",	"Overload bypass function",		[ "Disabled", "Enabled" ]],
+            ["option",	"display back to default page",		[ "Disabled", "Enabled" ]],
+            ["option",	"Overload restart",			[ "Disabled", "Enabled" ]],
+            ["option",	"Over temperature restart",		[ "Disabled", "Enabled" ]],
+            ["option",	"Backlight on",				[ "Disabled", "Enabled" ]],
+            ["option",	"Alarm primary source interrupt",	[ "Disabled", "Enabled" ]],
+            ["option",	"Fault code record",			[ "Disabled", "Enabled" ]],
+            ["int",	"Reserved",				""],
+        ],
+        "test_responses": [
+            b"",
+        ],
+    },
+
+#    "DI": {
+#        "name": "DI",
+#        "prefix": "^P005",
+#        "description": "Query default value of changeable paramer",
+#        "help": " -- Query default value of changeable paramer",
+#        "type": "QUERY",
+#        "response": [
+#        ],
+#        "test_responses": [
+#            b"",
+#        ],
+#    },
+
+    "MCHGCR": {
+        "name": "MCHGCR",
+        "prefix": "^P009",
+        "description": "Query Max. charging current selectable value",
+        "help": " -- Query Max. charging current selectable value",
+        "type": "QUERY",
+        "response": [
+            ["int", 	"Max. charging current value 1", 	"A"],
+            ["int", 	"Max. charging current value 2", 	"A"],
+            ["int", 	"Max. charging current value 3",	"A"],
+            ["int", 	"Max. charging current value 4",	"A"],
+            ["int", 	"Max. charging current value 5",	"A"],
+            ["int", 	"Max. charging current value 6",	"A"],
+            ["int", 	"Max. charging current value 7",	"A"],
+            ["int", 	"Max. charging current value 8",	"A"],
+        ],
+        "test_responses": [
+            b"^D034010,020,030,040,050,060,070,080\x161\r",
+        ],
+    },
+    "MUCHGCR": {
+        "name": "MUCHGCR",
+        "prefix": "^P010",
+        "description": "Query Max. AC charging current selectable value",
+        "help": " -- Query Max. AC charging current selectable value",
+        "type": "QUERY",
+        "response": [
+            ["int",	"Max. AC charging current value 1",	"A"],
+            ["int",	"Max. AC charging current value 2",	"A"],
+            ["int",	"Max. AC charging current value 3",	"A"],
+            ["int",	"Max. AC charging current value 4",	"A"],
+            ["int",	"Max. AC charging current value 5",	"A"],
+            ["int",	"Max. AC charging current value 6",	"A"],
+            ["int",	"Max. AC charging current value 7",	"A"],
+            ["int",	"Max. AC charging current value 8",	"A"],
+            ["int",	"Max. AC charging current value 9",	"A"],
         ],
         "test_responses": [
             b"",
@@ -95,14 +248,115 @@ COMMANDS = {
     },
     "PI": {
         "name": "PI",
+        "prefix": "^P005",
         "description": "Device Protocol Version inquiry",
         "help": " -- queries the device protocol version",
         "type": "QUERY",
-        "response": [["string", "Protocol Version", ""]],
+        "response":[
+            ["string",	"Protocol Version",			""]
+        ],
         "test_responses": [
             b"",
         ],
     },
+
+    ### SETTER ###
+#    "LON": {
+#        "name": "LON",
+#        "prefix": "^S007",
+#        "description": "Set enable/disable machine supply power to the loads",
+#        "help": " -- examples: LON1 (0: disable, 1: enable)",
+#        "type": "SETTER",
+#        "response": [
+#            ["ack", "Command execution", {"NAK": "Failed", "ACK": "Successful"}],
+#        ],
+#        "test_responses": [
+#            b"^1\x0b\xc2\r",
+#            b"^0\x1b\xe3\r",
+#        ],
+#        "regex": "LON([01])$",
+#    },
+
+    "POP": {
+        "name": "POP",
+        "prefix": "^S007",
+        "description": "Set output souce priority",
+        "help": " -- examples: POP (0: Solar-Utility-Battery, 1: Solar-Battery-Utility)",
+        "type": "SETTER",
+        "response": [
+            ["ack", "Command execution", {"NAK": "Failed", "ACK": "Successful"}],
+        ],
+        "test_responses": [
+            b"^1\x0b\xc2\r",
+            b"^0\x1b\xe3\r",
+        ],
+        "regex": "POP([01])$",
+    },
+
+    "PEI": {
+        "name": "PEI",
+        "prefix": "^S006",
+        "description": "Machine type, enable: Grid-Tie (Maunal Option 9)",
+        "help": " -- examples: PEI (enable Grid-Tie)",
+        "type": "SETTER",
+        "response": [
+            ["ack", "Command execution", {"NAK": "Failed", "ACK": "Successful"}],
+        ],
+        "test_responses": [
+            b"^1\x0b\xc2\r",
+            b"^0\x1b\xe3\r",
+        ],
+    },
+
+    "PDI": {
+        "name": "PDI",
+        "prefix": "^S006",
+        "description": "Machine type, disable: Grid-Tie do Off-Grid Tie (Maunal Option 9)",
+        "help": " -- examples: PDI (disable Grid-Tie)",
+        "type": "SETTER",
+        "response": [
+            ["ack", "Command execution", {"NAK": "Failed", "ACK": "Successful"}],
+        ],
+        "test_responses": [
+            b"^1\x0b\xc2\r",
+            b"^0\x1b\xe3\r",
+        ],
+    },
+
+
+# Not working "Command PCP01 was rejected"
+#    "PCP": {
+#        "name": "PCP",
+#        "prefix": "^S009",
+#        "description": "Set charging source priority",
+#        "help": " -- examples: PCP01 (Parallel machine ID (0-9) + 0: Solar first, 1: Solar and Utility, 2: Only solar)",
+#        "type": "SETTER",
+#        "response": [
+#            ["ack", "Command execution", {"NAK": "Failed", "ACK": "Successful"}],
+#        ],
+#        "test_responses": [
+#            b"^1\x0b\xc2\r",
+#            b"^0\x1b\xe3\r",
+#        ],
+#        "regex": "PCP([0-9][012])$",
+#    },
+
+    "PSP": {
+        "name": "PSP",
+        "prefix": "^S007",
+        "description": "Set solar power priority",
+        "help": " -- examples: PSP0 (0: Battery-Load-Utiliy (+AC Charge), 1: Load-Battery-Utiliy)",
+        "type": "SETTER",
+        "response": [
+            ["ack", "Command execution", {"NAK": "Failed", "ACK": "Successful"}],
+        ],
+        "test_responses": [
+            b"^1\x0b\xc2\r",
+            b"^0\x1b\xe3\r",
+        ],
+        "regex": "PSP([01])$",
+    },
+
 }
 
 
@@ -111,9 +365,27 @@ class pi18(AbstractProtocol):
         super().__init__()
         self._protocol_id = b"PI18"
         self.COMMANDS = COMMANDS
-        self.STATUS_COMMANDS = ["MOD", "GS", "ET"]
-        self.SETTINGS_COMMANDS = [
+        self.STATUS_COMMANDS = [
+            "ET",
+            "EY",
+            "ID",
+            "VFW",
+            "PIRI",
+            "GS",
+            "MOD",
+            #"FWS",
+            "FLAG",
+            #"DI",
+            "MCHGCR",
+            "MUCHGCR",
             "PI",
+        ]
+        self.SETTINGS_COMMANDS = [
+            "PEI"
+            "PDI"
+            "POP"
+            #"PCP",
+            "PSP",
         ]
         self.DEFAULT_COMMAND = "PI"
 
@@ -132,12 +404,19 @@ class pi18(AbstractProtocol):
         _cmd = bytes(self._command, "utf-8")
         _type = self._command_defn["type"]
 
-        data_length = len(_cmd) + 2 + 1
+        #data_length = len(_cmd) + 2 + 1
         if _type == "QUERY":
-            _prefix = f"^P{data_length:03}"
+              _prefix = self._command_defn["prefix"]
+        elif _type== "SETTER":
+              _prefix = self._command_defn["prefix"]
+              #data_length = len(_cmd) + 2 + 1
+              #_prefix = f"^S{data_length:03}"
+
         else:
-            _prefix = f"^S{data_length:03}"
+            _prefix = f"^P{data_length:03}"
+
         _pre_cmd = bytes(_prefix, "utf-8") + _cmd
+
         log.debug(f"_pre_cmd: {_pre_cmd}")
         # calculate the CRC
         crc_high, crc_low = crc(_pre_cmd)
@@ -145,6 +424,7 @@ class pi18(AbstractProtocol):
         # PI18 full command "^P005GS\x..\x..\r"
         _crc = bytes([crc_high, crc_low, 13])
         full_command = _pre_cmd + _crc
+
         log.debug(f"full command: {full_command}")
         return full_command
 


### PR DESCRIPTION
I have now used your software for so long, and she works great.
I have updated my state, and tested, and then the Protocol PI18 also adapted something to the needs I have.
And here's what works and what I needed.
If I have more time I look that I bring the other options to run. 

Switching Mashine Type from Off-Grid to Grid-Tie. 

```
mpp-solar -p /dev/hidraw0 -P PI18 -c PIRI,PEI,PIRI
Command: PIRI - Device rated information
------------------------------------------------------------
Parameter                       Value           Unit
ac_input_rated_voltage          230.0           V
ac_input_rated_current          21.7            A
ac_output_rated_voltage         230.0           V
ac_output_rated_frequency       50.0            Hz
ac_output_rated_current         21.7            A
ac_output_rating_apparent_power 5000            VA
ac_output_rating_active_power   5000            W
battery_rated_voltage           48.0            V
battery_re-charge_voltage       50.0            V
battery_re-discharge_voltage    54.0            V
battery_under_voltage           45.0            V
battery_bulk_voltage            55.2            V
battery_float_voltage           54.5            V
battery_type                    User
max_ac_charging_current         10              A
max_charging_current            60              A
input_voltage_rang              UPS
output_source_priority          Solar-Battery-Utility
charger_source_priority         Solar and Utility
parallel_max_num                9
machine_type                    Off-Grid
topology                        transformerless
output_model_setting            Single module
solar_power_priority            Load-Battery-Utiliy
mppt_strings                    1
unknown_value_in_response_25    00
Command: PEI - Machine type, enable: Grid-Tie (Maunal Option 9)
------------------------------------------------------------
Parameter                       Value           Unit
pei
Command: PIRI - Device rated information
------------------------------------------------------------
Parameter                       Value           Unit
ac_input_rated_voltage          230.0           V
ac_input_rated_current          21.7            A
ac_output_rated_voltage         230.0           V
ac_output_rated_frequency       50.0            Hz
ac_output_rated_current         21.7            A
ac_output_rating_apparent_power 5000            VA
ac_output_rating_active_power   5000            W
battery_rated_voltage           48.0            V
battery_re-charge_voltage       50.0            V
battery_re-discharge_voltage    54.0            V
battery_under_voltage           45.0            V
battery_bulk_voltage            55.2            V
battery_float_voltage           54.5            V
battery_type                    User
max_ac_charging_current         10              A
max_charging_current            60              A
input_voltage_rang              UPS
output_source_priority          Solar-Battery-Utility
charger_source_priority         Solar and Utility
parallel_max_num                9
machine_type                    Grid-Tie
topology                        transformerless
output_model_setting            Single module
solar_power_priority            Load-Battery-Utiliy
mppt_strings                    1
unknown_value_in_response_25    00
```

Switching solar_power_priority from LBU to BLU

```
mpp-solar -p /dev/hidraw0 -P PI18 -c PIRI,PSP0,PI RI
Command: PIRI - Device rated information
------------------------------------------------------------
Parameter                       Value           Unit
ac_input_rated_voltage          230.0           V
ac_input_rated_current          21.7            A
ac_output_rated_voltage         230.0           V
ac_output_rated_frequency       50.0            Hz
ac_output_rated_current         21.7            A
ac_output_rating_apparent_power 5000            VA
ac_output_rating_active_power   5000            W
battery_rated_voltage           48.0            V
battery_re-charge_voltage       50.0            V
battery_re-discharge_voltage    54.0            V
battery_under_voltage           45.0            V
battery_bulk_voltage            55.2            V
battery_float_voltage           54.5            V
battery_type                    User
max_ac_charging_current         10              A
max_charging_current            60              A
input_voltage_rang              UPS
output_source_priority          Solar-Battery-Utility
charger_source_priority         Solar and Utility
parallel_max_num                9
machine_type                    Grid-Tie
topology                        transformerless
output_model_setting            Single module
solar_power_priority            Load-Battery-Utiliy
mppt_strings                    1
unknown_value_in_response_25    00
Command: PSP0 - Set solar power priority
------------------------------------------------------------
Parameter                       Value           Unit
psp
Command: PIRI - Device rated information
------------------------------------------------------------
Parameter                       Value           Unit
ac_input_rated_voltage          230.0           V
ac_input_rated_current          21.7            A
ac_output_rated_voltage         230.0           V
ac_output_rated_frequency       50.0            Hz
ac_output_rated_current         21.7            A
ac_output_rating_apparent_power 5000            VA
ac_output_rating_active_power   5000            W
battery_rated_voltage           48.0            V
battery_re-charge_voltage       50.0            V
battery_re-discharge_voltage    54.0            V
battery_under_voltage           45.0            V
battery_bulk_voltage            55.2            V
battery_float_voltage           54.5            V
battery_type                    User
max_ac_charging_current         10              A
max_charging_current            60              A
input_voltage_rang              UPS
output_source_priority          Solar-Battery-Utility
charger_source_priority         Solar and Utility
parallel_max_num                9
machine_type                    Grid-Tie
topology                        transformerless
output_model_setting            Single module
solar_power_priority            Battery-Load-Utiliy
mppt_strings                    1
unknown_value_in_response_25    00
```
best regards
Alexander 