### PR TITLE
Update hass_mqtt.py

### DIFF
--- a/mppsolar/outputs/hass_mqtt.py
+++ b/mppsolar/outputs/hass_mqtt.py
@@ -52,23 +52,36 @@ class hass_mqtt(mqtt):
                 # <discovery_prefix>/<component>/[<node_id>/]<object_id>/config
                 # topic "homeassistant/binary_sensor/garden/config"
                 # msg '{"name": "garden", "device_class": "motion", "state_topic": "homeassistant/binary_sensor/garden/state", "unit_of_measurement": "°C"}'
-                topic = f"homeassistant/sensor/mpp_{tag}_{key}/config"
-                topic = topic.replace(" ", "_")
-                name = f"{tag} {_key}"
-                if unit == "W":
-                    payload = f'{{"name": "{name}", "state_topic": "homeassistant/sensor/mpp_{tag}_{key}/state", "unit_of_measurement": "{unit}", "unique_id": "mpp_{tag}_{key}", "state_class": "measurement", "device_class": "power", "force_update": "true" }}'
+                if unit == "bool":
+                    topic = f"homeassistant/binary_sensor/mpp_{tag}_{key}/config"
+                    topic = topic.replace(" ", "_")
+                    name = f"{tag} {_key}"
+                    payload = f'{{"name": "{name}", "state_topic": "homeassistant/binary_sensor/mpp_{tag}_{key}/state", "unique_id": "mpp_{tag}_{key}", "force_update": "true" }}'
+                    msg = {"topic": topic, "payload": payload}
+                    msgs.append(msg)
+                    topic = f"homeassistant/binary_sensor/mpp_{tag}_{key}/state"
+                    msg = {"topic": topic, "payload": value}
+                    msgs.append(msg)
                 else:
-                    payload = f'{{"name": "{name}", "state_topic": "homeassistant/sensor/mpp_{tag}_{key}/state", "unit_of_measurement": "{unit}", "unique_id": "mpp_{tag}_{key}", "force_update": "true" }}'
-                # msg = {"topic": topic, "payload": payload, "retain": True}
-                msg = {"topic": topic, "payload": payload}
-                msgs.append(msg)
-                #
-                # VALUE SETTING
-                #
-                # unit = data[key][1]
-                # 'tag'/status/total_output_active_power/value 1250
-                # 'tag'/status/total_output_active_power/unit W
-                topic = f"homeassistant/sensor/mpp_{tag}_{key}/state"
-                msg = {"topic": topic, "payload": value}
-                msgs.append(msg)
+                    topic = f"homeassistant/sensor/mpp_{tag}_{key}/config"
+                    topic = topic.replace(" ", "_")
+                    name = f"{tag} {_key}"
+                    if unit == "W":
+                        payload = f'{{"name": "{name}", "state_topic": "homeassistant/sensor/mpp_{tag}_{key}/state", "unit_of_measurement": "{unit}", "unique_id": "mpp_{tag}_{key}", "state_class": "measurement", "device_class": "power", "force_update": "true" }}'
+                    elif unit == "":
+                        payload = f'{{"name": "{name}", "state_topic": "homeassistant/sensor/mpp_{tag}_{key}/state", "unique_id": "mpp_{tag}_{key}", "force_update": "true" }}'
+                    else:
+                        payload = f'{{"name": "{name}", "state_topic": "homeassistant/sensor/mpp_{tag}_{key}/state", "unit_of_measurement": "{unit}", "unique_id": "mpp_{tag}_{key}", "force_update": "true" }}'
+                    # msg = {"topic": topic, "payload": payload, "retain": True}
+                    msg = {"topic": topic, "payload": payload}
+                    msgs.append(msg)
+                    #
+                    # VALUE SETTING
+                    #
+                    # unit = data[key][1]
+                    # 'tag'/status/total_output_active_power/value 1250
+                    # 'tag'/status/total_output_active_power/unit W
+                    topic = f"homeassistant/sensor/mpp_{tag}_{key}/state"
+                    msg = {"topic": topic, "payload": value}
+                    msgs.append(msg)
         return msgs


### PR DESCRIPTION
Hi @jblance 

I'm using your great work for collecting inverter data into Home Assistant (HA), but I also like to improve it a bit:

1)
I think, if we use "binary_sensor" instead of "sensor" for boolean parameters in the mqtt topics, HA will discover them as binary sensors, too. We should then see a blue/yellow eye icon depending on state and 'state_color: true' in the entity card. [https://www.home-assistant.io/integrations/binary_sensor/] [https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery]

2)
Parameters/Entities without unit don't need and better don't have "unit_of_measurement" declaration. Even with an empty "" unit statement HA uses them as with unit. So the history graph card in HA then shows an empty line graph instead of a horizontal bar chart. e.g.: https://imgur.com/3ha8K97 original graph and above a bar of a copy as a template entity without "unit_of_measurement" (sadly no change in the given time) [https://www.home-assistant.io/dashboards/history-graph]

I hope you can agree with my point of view, because I absolutely don't know how to change this in my running installation! And because I don't speak python you better doublecheck my changes! (There's no endif, isn't? Is it just the four spaces to right/left for loops?)

And if you take over my changes, I just have to enter "sudo pip install -U mppsolar" and
"systemctl --user restart mpp-solar" to update and restart mpp-solar on my pi?

Last but not least:
The PI30 command QMN queries the Inverter Model. This isn't included in your code and I didn't find the right file/place for a proposal. Maybe you find some time to add this. But while it's very clear to read (just with leading "(" and ending "³", it's no problem for me.