### PR TITLE
Proposed changes powermon to support adhoc commands and better scheduling

### DIFF
--- a/powermon.yaml
+++ b/powermon.yaml
@@ -55,10 +55,10 @@ mqttbroker:
   user: null
   pass: null
   adhoc_commands:
-  topic: Test_Inverter/commands
-  outputs:
-  - name: screen
-    tag: Test_Inverter
+    topic: Test_Inverter/commands
+    outputs:
+    - name: screen
+      tag: Test_Inverter
 daemon:
   type: systemd
   keepalive: 10

--- a/powermon.yaml
+++ b/powermon.yaml
@@ -1,6 +1,6 @@
 # yaml config for powermon
-devices:
-- name: Test_Inverter
+device:
+  name: Test_Inverter
   id: 123456789
   model: 8048MAX
   manufacturer: MPP-Solar
@@ -14,20 +14,7 @@ devices:
 scheduling:
   loop: 60
   schedules:
-  #Define a schedule for a device to listen to adhoc commands
-  - name: adhoc_listener
-    device_id: 123456789
-    type: loop
-    run_every_x_loops: 1 # runs every 60 seconds 
-    commands:
-    - command: adhoc #the command name could be anything
-      type: listen
-      command_topic: /mpp-solar/commands/ #mqtt topic that will listen for commands
-      outputs:
-      - name: mqtt
-        tag: Test_Inverter
   - name: QPIGS_5_minutes
-    device_id: 123456789
     type: loop
     run_every_x_loops: 5 #will run every 5 minutes
     commands:
@@ -42,7 +29,6 @@ scheduling:
       - name: screen
         tag: Test_Inverter
   - name: 3pm_check
-    device_id: 123456789
     type: time
     time: 15:00:00 #run at 3pm everyday
     commands:
@@ -68,6 +54,11 @@ mqttbroker:
   port: 1883
   user: null
   pass: null
+  adhoc_commands:
+  topic: Test_Inverter/commands
+  outputs:
+  - name: screen
+    tag: Test_Inverter
 daemon:
   type: systemd
   keepalive: 10

--- a/powermon.yaml
+++ b/powermon.yaml
@@ -10,26 +10,42 @@ devices:
     type: test
     protocol: PI30MAX
 
+#Separate the schedule from the device definition
 scheduling:
   loop: 60
   schedules:
-  - id: 1
+  #Define a schedule for a device to listen to adhoc commands
+  - name: adhoc_listener
+    device_id: 123456789
+    type: loop
+    run_every_x_loops: 1 # runs every 60 seconds 
+    commands:
+    - command: adhoc #the command name could be anything
+      type: listen
+      command_topic: /mpp-solar/commands/ #mqtt topic that will listen for commands
+      outputs:
+      - name: mqtt
+        tag: Test_Inverter
+  - name: QPIGS_5_minutes
     device_id: 123456789
     type: loop
     run_every_x_loops: 5 #will run every 5 minutes
     commands:
     - command: QPIGS
+      type: basic #default command type is basic
       outputs:
       - name: screen
         tag: Test_Inverter
     - command: QPIGS2
+      type: basic
       outputs:
       - name: screen
         tag: Test_Inverter
-  - id: 2
+  - name: 3pm_check
     device_id: 123456789
     type: time
     time: 15:00:00 #run at 3pm everyday
+    commands:
     - command: QPGS0
       outputs:
       - name: screen
@@ -41,22 +57,17 @@ scheduling:
         tag: Test_Inverter
         filter: ^inverter_charge
     - command: QED
-      # f_command: f'QED{(date.today()-timedelta(days=1)).strftime("%Y%m%d")}'
       f_command: f'QED{(date.today()).strftime("%Y%m%d")}'
       outputs:
       - name: screen
         tag: Test_Inverter
         filter: ^pv
+
 mqttbroker:
   name: localhost
   port: 1883
   user: null
   pass: null
-  adhoc_commands:
-    topic: Test_Inverter/commands
-    outputs:
-    - name: screen
-      tag: Test_Inverter
 daemon:
   type: systemd
   keepalive: 10

--- a/powermon.yaml
+++ b/powermon.yaml
@@ -1,6 +1,6 @@
 # yaml config for powermon
-device:
-  name: Test_Inverter
+devices:
+- name: Test_Inverter
   id: 123456789
   model: 8048MAX
   manufacturer: MPP-Solar
@@ -9,32 +9,44 @@ device:
     path: /dev/ttyUSB0
     type: test
     protocol: PI30MAX
-  commands:
-  - command: QPIGS
-    outputs:
-    - name: screen
-      tag: Test_Inverter
-  - command: QPIGS2
-    outputs:
-    - name: screen
-      tag: Test_Inverter
-  - command: QPGS0
-    outputs:
-    - name: screen
-      tag: Test_Inverter
-      filter: ^serial|^work|^charger|^fault
-  - command: Q1
-    outputs:
-    - name: screen
-      tag: Test_Inverter
-      filter: ^inverter_charge
-  - command: QED
-    # f_command: f'QED{(date.today()-timedelta(days=1)).strftime("%Y%m%d")}'
-    f_command: f'QED{(date.today()).strftime("%Y%m%d")}'
-    outputs:
-    - name: screen
-      tag: Test_Inverter
-      filter: ^pv
+
+scheduling:
+  loop: 60
+  schedules:
+  - id: 1
+    device_id: 123456789
+    type: loop
+    run_every_x_loops: 5 #will run every 5 minutes
+    commands:
+    - command: QPIGS
+      outputs:
+      - name: screen
+        tag: Test_Inverter
+    - command: QPIGS2
+      outputs:
+      - name: screen
+        tag: Test_Inverter
+  - id: 2
+    device_id: 123456789
+    type: time
+    time: 15:00:00 #run at 3pm everyday
+    - command: QPGS0
+      outputs:
+      - name: screen
+        tag: Test_Inverter
+        filter: ^serial|^work|^charger|^fault
+    - command: Q1
+      outputs:
+      - name: screen
+        tag: Test_Inverter
+        filter: ^inverter_charge
+    - command: QED
+      # f_command: f'QED{(date.today()-timedelta(days=1)).strftime("%Y%m%d")}'
+      f_command: f'QED{(date.today()).strftime("%Y%m%d")}'
+      outputs:
+      - name: screen
+        tag: Test_Inverter
+        filter: ^pv
 mqttbroker:
   name: localhost
   port: 1883
@@ -49,4 +61,4 @@ daemon:
   type: systemd
   keepalive: 10
 #daemon: initd
-loop: 60
+


### PR DESCRIPTION
I would like to get your input before starting on some changes to the powermon. This isn't a real pull request, I tried to write it up as a discussion but the code blocks weren't very good. I'm just getting familiar with yaml so consider this pseudo code.

I would like to separate the devices from the schedule of the commands they are going to run. I would also like to move the adhoc listener definition into a schedule. This will allow multiple devices to be able to listen for adhoc commands.