### PR TITLE
Adding a pylint config file for fixing complaint with pydantic import

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+extension-pkg-whitelist=pydantic


### PR DESCRIPTION
Makes all the reported pydantic import errors go away.