### PR TITLE
Powermon PI18 first steps

### DIFF
--- a/docker/dev/config/powermon-qpigs.yaml
+++ b/docker/dev/config/powermon-qpigs.yaml
@@ -17,7 +17,7 @@ commands:
     # format: raw
     # format: simple
     # format: table
-    format: 
+    format:
       type: htmltable
       #keep_case: True
       #remove_spaces: False

--- a/docker/dev/config/powermon.yaml
+++ b/docker/dev/config/powermon.yaml
@@ -18,10 +18,9 @@ commands:
     every: 100  # seconds
   outputs:
   - type: screen
-    format: 
+    format:
       type: hass
 
-          
 mqttbroker:
   name: localhost
   port: 1883

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -53,3 +53,15 @@ services:
    devices:
      - /dev/ttyUSB0:/dev/ttyUSB0
 ```
+
+Build Dev Container
+change to Git Directory 
+```
+docker build -t YOUR_TAG -f docker/dev/Dockerfile .
+```
+
+Stop mpp-sor container and Run Powermon one time
+```
+docker compose -f /etc/docker/docker-compose.yaml stop; sleep 3; docker run --rm --volume=/etc/mpp-solar:/etc/mpp-solar --device=/dev/hidraw0 pi18_powermon powermon -C /etc/mpp-solar/powermon.conf -1; docker compose -f /etc/docker/docker-compose.yaml start;
+
+```

--- a/powermon/commands/response_definition.py
+++ b/powermon/commands/response_definition.py
@@ -8,6 +8,7 @@ import calendar #needed for INFO type evaluating templates
 class ResponseType(LowercaseStrEnum):
     ACK = auto()
     INT = auto()
+    TEN_INT = auto()
     OPTION = auto()
     BYTES = "bytes.decode" #can't use auto() for this value
     FLOAT = auto()
@@ -92,7 +93,16 @@ class ResponseDefinition(ABC):
                                          device_class=device_class,
                                          state_class=state_class,
                                          icon=icon)
-            
+        
+        elif response_definition_type == ResponseType.TEN_INT:
+            unit = response_definition_config[3]
+            return ResponseDefinitionTenInt(index=response_definition_index,
+                                         description=response_definition_description,
+                                         unit=unit,
+                                         device_class=device_class,
+                                         state_class=state_class,
+                                         icon=icon)
+        
         elif response_definition_type == ResponseType.OPTION:
             options : list[str] = response_definition_config[3]
             return ResponseDefinitionOption(index=response_definition_index,
@@ -227,6 +237,39 @@ class ResponseDefinitionInt(ResponseDefinition):
     
     def translate_raw_response(self, raw_value) -> str:
         return int(raw_value.decode())
+    
+    
+    def response_from_raw_values(self, raw_value) -> list[Response]:
+        value = self.translate_raw_response(raw_value)
+        return [Response(data_name=self.description,
+                        data_value=str(value),
+                        data_unit=self.unit,
+                        device_class=self.device_class,
+                        state_class=self.state_class,
+                        icon=self.icon)]
+    
+    def get_description(self) -> str:
+        return self.description
+      
+# Same INT but base 10
+class ResponseDefinitionTenInt(ResponseDefinition):
+    def __init__(self, index: int, description: str, unit : str,
+                 device_class: str = None,
+                 state_class: str = None,
+                 icon: str = None):
+        self.index = index
+        self.description = description
+        self.unit = unit
+        self.device_class = device_class
+        self.state_class = state_class
+        self.icon = icon
+    
+    def is_valid_response(self, value) -> bool:
+        #Do we need to check if it's negative? Should we have max and min bounds?
+        return isinstance(value, int) / 10
+    
+    def translate_raw_response(self, raw_value) -> str:
+        return int(raw_value.decode()) / 10
     
     
     def response_from_raw_values(self, raw_value) -> list[Response]:

--- a/powermon/protocols/pi18.py
+++ b/powermon/protocols/pi18.py
@@ -1,0 +1,842 @@
+import logging
+
+from powermon.commands.result import ResultType
+from powermon.protocols.abstractprotocol import AbstractProtocol
+from mppsolar.protocols.protocol_helpers import crcPI as crc
+from powermon.commands.result import Result
+from powermon.commands.response_definition import ResponseType
+
+log = logging.getLogger("pi18")
+
+SETTER_COMMANDS = {
+    "MCHGC": {
+        "name": "MCHGC",
+        "prefix": "^S013",
+        "description": "Set Battery Max Charging Current Solar + AC             (Manual Option 11)",
+        "help": " -- example: MCHGC0,030        (set unit 0 [0-9] to max charging current of  30A [    010 020 030 040 050 060 070 080])",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "MCHGC([0-9],0[1-8]0)$",
+    },
+    "MUCHGC": {
+        "name": "MUCHGC",
+        "prefix": "^S014",
+        "description": "Set Battery Max AC Charging Current                     (Manual Option 13)",
+        "help": " -- example: MUCHGC0,030       (set unit 0 [0-9] utility charging current to 30A [002 010 020 030 040 050 060 070 080])",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"",],
+        "regex": "MUCHGC([0-9]),(002|0[1-8]0)$",
+    },
+    "PBT": {
+        "name": "PBT",
+        "prefix": "^S007",
+        "description": "Set Battery Type                                        (Manual Option 14)",
+        "help": " -- example: PBT0              (set battery as PBT0 [0: AGM], PBT1 [1: FLOODED], PBT2 [2: USER])",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "PBT([012])$",
+    },
+    "PCP": {
+        "name": "PCP",
+        "prefix": "^S009",
+        "description": "Set charging source priority                            (Manual Option 10)",
+        "help": " -- example: PCP0,1            (set unit 0 [0-9] to 0: Solar first, 1: Solar and Utility, 2: Only solar)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"^1\x0b\xc2\r", b"^0\x1b\xe3\r",],
+        "regex": "PCP([0-9],[012])$",
+    },
+#    "PE": {
+#        "name": "PE",
+#        "description": "Set the enabled state of an Inverter setting",
+#        "help": " -- examples: PEa - enable a (buzzer) [a=buzzer, b=overload bypass, j=power saving, K=LCD go to default after 1min, u=overload restart, v=overtemp restart, x=backlight, y=alarm on primary source interrupt, z=fault code record]",
+#        "response_type": ResultType.ACK,
+#        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+#        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+#        "regex": "PE(.+)$",
+#    },
+#   "PD": {
+#       "name": "PD",
+#       "description": "Set the disabled state of an Inverter setting",
+#       "help": " -- examples: PDa - disable a (buzzer) [a=buzzer, b=overload bypass, j=power saving, K=LCD go to default after 1min, u=overload restart, v=overtemp restart, x=backlight, y=alarm on primary source interrupt, z=fault code record]",
+#       "response_type": ResultType.ACK,
+#       "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+#       "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+#       "regex": "PD(.+)$",
+#   },
+#    "PF": {
+#        "name": "PF",
+#        "description": "Set Control Parameters to Default Values",
+#        "help": " -- example PF (reset control parameters to defaults)",
+#        "response_type": ResultType.ACK,
+#        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+#        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+#    },
+    "PGR": {
+        "name": "PGR",
+        "description": "Set Grid Working Range",
+        "help": " -- examples: PCR00 (set device working range to appliance), PCR01 (set device working range to UPS)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "PGR(0[01])$",
+    },
+    "POP": {
+        "name": "POP",
+        "description": "Set Device Output Source Priority",
+        "help": " -- examples: POP00 (set utility first), POP01 (set solar first), POP02 (set SBU priority)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "POP(0[012])$",
+    },
+    "POPLG": {
+        "name": "POPLG",
+        "description": "Set Device Operation Logic",
+        "help": " -- examples: POPLG00 (set Auto mode), POPLG01 (set Online mode), POPLG02 (set ECO mode)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "POPLG(0[012])$",
+    },
+    "POPM": {
+        "name": "POPM",
+        "description": "Set Device Output Mode (for 4000/5000)",
+        "help": " -- examples: POPM01 (set unit 0 to 1 - parallel output), POPM10 (set unit 1 to 0 - single machine output), POPM02 (set unit 0 to 2 - phase 1 of 3), POPM13 (set unit 1 to 3 - phase 2 of 3), POPM24 (set unit 2 to 4 - phase 3 of 3)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "POPM(\\d[01234])$",
+    },
+    "PPCP": {
+        "name": "PPCP",
+        "description": "Set Parallel Device Charger Priority (for 4000/5000)",
+        "help": " -- examples: PPCP000 (set unit 1 to 00 - utility first), PPCP101 (set unit 1 to 01 - solar first), PPCP202 (set unit 2 to 02 - solar and utility), PPCP003 (set unit 0 to 03 - solar only charging)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "PPCP(\\d0[0123])$",
+    },
+    "PPVOKC": {
+        "name": "PPVOKC",
+        "description": "Set PV OK Condition",
+        "help": " -- examples: PPVOKC0 (as long as one unit has connected PV, parallel system will consider PV OK), PPVOKC1 (only if all inverters have connected PV, parallel system will consider PV OK)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "PPVOKC([01])$",
+    },
+    "PSDV": {
+        "name": "PSDV",
+        "description": "Set Battery Cut-off Voltage",
+        "help": " -- example PSDV40.0 - set battery cut-off voltage to 40V (40.0 - 48.0V for 48V unit)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "PSDV(\\d\\d\\.\\d)$",
+    },
+    "PSPB": {
+        "name": "PSPB",
+        "description": "Set Solar Power Balance",
+        "help": " -- examples: PSPB0 (PV input max current will be the max charged current), PSPB1 (PV input max power will be the sum of the max charge power and loads power)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "PSPB([01])$",
+    },
+    "PBATCD": {
+        "name": "PBATCD",
+        "description": "Battery charge/discharge controlling command",
+        "help": " -- examples: PBATCDxxx (please read description, use carefully)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "PBATCD([01][01][01])$",
+    },
+    "DAT": {
+        "name": "DAT",
+        "description": "Set Date Time",
+        "help": " -- examples: DATYYYYMMDDHHMMSS (14 digits after DAT)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "DAT(\\d\\d\\d\\d\\d\\d\\d\\d\\d\\d\\d\\d\\d\\d)$",
+    },
+    "PBATMAXDISC": {
+        "name": "PBATMAXDISC",
+        "description": "Battery max discharge current",
+        "help": " -- examples: PBATMAXDISCxxx (000- disable or 030-150A)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "PBATMAXDISC([01]\\d\\d)$",
+    },
+    "BTA": {
+        "name": "BTA",
+        "description": "Calibrate inverter battery voltage",
+        "help": " -- examples: BTA-01 (reduce inverter reading by 0.05V), BTA+09 (increase inverter reading by 0.45V)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r",],
+        "regex": "BTA([-+]0\\d)$",
+    },
+    "PSAVE": {
+        "name": "PSAVE",
+        "description": "Save EEPROM changes",
+        "help": " -- examples: PSAVE (save changes to eeprom)",
+        "response_type": ResultType.ACK,
+        "response": [[0, "Command execution", ResponseType.ACK, {"NAK": "Failed", "ACK": "Successful"}]],
+        "test_responses": [b"(NAK\x73\x73\r", b"(ACK\x39\x20\r"],
+    },
+}
+
+QUERY_COMMANDS = {
+    "Q1": {
+        "name": "Q1",
+        "description": "Q1 query",
+        "response_type": ResultType.INDEXED,
+        "response": [
+            [0, "Time until the end of absorb charging", ResponseType.INT, "sec"],
+            [1, "Time until the end of float charging", ResponseType.INT, "sec"],
+            [2, "SCC Flag", ResponseType.OPTION, ["SCC not communicating?", "SCC is powered and communicating"]],
+            [3, "AllowSccOnFlag", ResponseType.BYTES, ""],
+            [4, "ChargeAverageCurrent", ResponseType.BYTES, ""],
+            [5, "SCC PWM temperature", ResponseType.INT, "\u00b0C", {"device-class": "temperature"}],
+            [6, "Inverter temperature", ResponseType.INT, "\u00b0C", {"device-class": "temperature"}],
+            [7, "Battery temperature", ResponseType.INT, "\u00b0C", {"device-class": "temperature"}],
+            [8, "Transformer temperature", ResponseType.INT, "\u00b0C", {"device-class": "temperature"}],
+            [9, "GPIO13", ResponseType.INT, ""],
+            [10, "Fan lock status", ResponseType.OPTION, ["Not locked", "Locked"]],
+            [11, "Not used", ResponseType.BYTES, ""],
+            [12, "Fan PWM speed", ResponseType.INT, "%"],
+            [13, "SCC charge power", ResponseType.INT, "W", {"icon": "mdi:solar-power", "device-class": "power"}],
+            [14, "Parallel Warning", ResponseType.BYTES, ""],
+            [15, "Sync frequency", ResponseType.FLOAT, ""],
+            [
+                16,
+                "Inverter charge status",
+                ResponseType.STR_KEYED,
+                {"10": "nocharging", "11": "bulk stage", "12": "absorb", "13": "float"},
+                {"icon": "mdi:book-open"},
+            ],
+        ],
+        "test_responses": [b"(00000 00000 01 01 00 059 045 053 068 00 00 000 0040 0580 0000 50.00 139\xb9\r"],
+    },
+    "QBOOT": {
+        "name": "QBOOT",
+        "description": "DSP Has Bootstrap inquiry",
+        "response_type": ResultType.INDEXED,
+        "response": [[0, "DSP Has Bootstrap", ResponseType.OPTION, ["No", "Yes"]]],
+        "test_responses": [b"(0\xb9\x1c\r"],
+    },
+    "QDI": {
+        "name": "QDI",
+        "description": "Default Settings inquiry",
+        "help": " -- queries the default settings from the Inverter",
+        "response_type": ResultType.INDEXED,
+        "response": [
+            [0, "AC Output Voltage", ResponseType.FLOAT, "V"],
+            [1, "AC Output Frequency", ResponseType.FLOAT, "Hz"],
+            [2, "Max AC Charging Current", ResponseType.INT, "A"],
+            [3, "Battery Under Voltage", ResponseType.FLOAT, "V"],
+            [4, "Battery Float Charge Voltage", ResponseType.FLOAT, "V"],
+            [5, "Battery Bulk Charge Voltage", ResponseType.FLOAT, "V"],
+            [6, "Battery Recharge Voltage", ResponseType.FLOAT, "V"],
+            [7, "Max Charging Current", ResponseType.INT, "A"],
+            [8, "Input Voltage Range", ResponseType.OPTION, ["Appliance", "UPS"]],
+            [9, "Output Source Priority", ResponseType.OPTION, ["Utility first", "Solar first", "SBU first"]],
+            [
+                10,
+                "Charger Source Priority",
+                ResponseType.OPTION,
+                ["Utility first", "Solar first", "Solar + Utility", "Only solar charging permitted"],
+            ],
+            [11, "Battery Type", ResponseType.OPTION, ["AGM", "Flooded", "User"]],
+            [12, "Buzzer", ResponseType.OPTION, ["enabled", "disabled"]],
+            [13, "Power saving", ResponseType.OPTION, ["disabled", "enabled"]],
+            [14, "Overload restart", ResponseType.OPTION, ["disabled", "enabled"]],
+            [15, "Over temperature restart", ResponseType.OPTION, ["disabled", "enabled"]],
+            [16, "LCD Backlight", ResponseType.OPTION, ["disabled", "enabled"]],
+            [17, "Primary source interrupt alarm", ResponseType.OPTION, ["disabled", "enabled"]],
+            [18, "Record fault code", ResponseType.OPTION, ["disabled", "enabled"]],
+            [19, "Overload bypass", ResponseType.OPTION, ["disabled", "enabled"]],
+            [20, "LCD reset to default", ResponseType.OPTION, ["disabled", "enabled"]],
+            [
+                21,
+                "Output mode",
+                ResponseType.OPTION,
+                [
+                    "single machine output",
+                    "parallel output",
+                    "Phase 1 of 3 Phase output",
+                    "Phase 2 of 3 Phase output",
+                    "Phase 3 of 3 Phase output",
+                    "Phase 1 of 2 phase output",
+                    "Phase 2 of 2 phase output",
+                    "unknown output phase",
+                ],
+            ],
+            [22, "Battery Redischarge Voltage", ResponseType.FLOAT, "V"],
+            [
+                23,
+                "PV OK condition",
+                ResponseType.OPTION,
+                [
+                    "As long as one unit of inverters has connect PV, parallel system will consider PV OK",
+                    "Only All of inverters have connect PV, parallel system will consider PV OK",
+                ],
+            ],
+            [
+                24,
+                "PV Power Balance",
+                ResponseType.OPTION,
+                [
+                    "PV input max current will be the max charged current",
+                    "PV input max power will be the sum of the max charged power and loads power",
+                ],
+            ],
+            [25, "Unknown Value", ResponseType.INT, ""],
+        ],
+        "test_responses": [
+            b"(230.0 50.0 0030 42.0 54.0 56.4 46.0 60 0 0 2 0 0 0 0 0 1 1 0 0 1 0 54.0 0 1 000\x9E\x60\r"
+        ],
+    },
+    "QFLAG": {
+        "name": "QFLAG",
+        "description": "Flag Status inquiry",
+        "help": " -- queries the enabled / disabled state of various Inverter settings (e.g. buzzer, overload, interrupt alarm)",
+        "response_type": ResultType.INDEXED,
+        "response": [
+            [
+                0,
+                "Device Status",
+                ResponseType.ENFLAGS,
+                {
+                    "a": {"name": "Buzzer", "state": "disabled"},
+                    "b": {"name": "Overload Bypass", "state": "disabled"},
+                    "j": {"name": "Power Saving", "state": "disabled"},
+                    "k": {"name": "LCD Reset to Default", "state": "disabled"},
+                    "u": {"name": "Overload Restart", "state": "disabled"},
+                    "v": {"name": "Over Temperature Restart", "state": "disabled"},
+                    "x": {"name": "LCD Backlight", "state": "disabled"},
+                    "y": {"name": "Primary Source Interrupt Alarm", "state": "disabled"},
+                    "z": {"name": "Record Fault Code", "state": "disabled"},
+                },
+            ]
+        ],
+        "test_responses": [b"(EakxyDbjuvz\x2F\x29\r"],
+    },
+    "QID": {
+        "name": "QID",
+        "description": "Device Serial Number inquiry",
+        "help": " -- queries the device serial number",
+        "response_type": ResultType.INDEXED,
+        "response": [[0, "Serial Number", ResponseType.BYTES, ""]],
+        "test_responses": [b"(9293333010501\xbb\x07\r"],
+    },
+    "QMCHGCR": {
+        "name": "QMCHGCR",
+        "description": "Max Charging Current Options inquiry",
+        "help": " -- queries the maximum charging current setting of the Inverter",
+        "response_type": ResultType.MULTIVALUED,
+        "response": [[0, "Max Charging Current Options", ResponseType.STRING, "A"]],
+        "test_responses": [b"(010 020 030 040 050 060 070 080 090 100 110 120\x0c\xcb\r"],
+    },
+    "QMOD": {
+        "name": "QMOD",
+        "description": "Mode inquiry",
+        "help": " -- queries the Inverter mode",
+        "response_type": ResultType.INDEXED,
+        "response": [
+            [
+                0,
+                "Device Mode",
+                ResponseType.STR_KEYED,
+                {"P": "Power on", "S": "Standby", "L": "Line", "B": "Battery", "F": "Fault", "H": "Power saving"},
+            ]
+        ],
+        "test_responses": [b"(S\xe5\xd9\r"],
+    },
+    "QMN": {
+        "name": "QMN",
+        "description": "Model Name Inquiry",
+        "response_type": ResultType.INDEXED,
+        "response": [[0, "Model Name", ResponseType.BYTES, ""]],
+        "test_responses": [b"(MKS2-8000\xb2\x8d\r",],
+    },
+    "QGMN": {
+        "name": "QGMN",
+        "description": "General Model Name Inquiry",
+        "response_type": ResultType.INDEXED,
+        "response": [[0, "General Model Number", ResponseType.BYTES, ""]],
+        "test_responses": [b"(044\xc8\xae\r",],
+    },
+    "QMUCHGCR": {
+        "name": "QMUCHGCR",
+        "description": "Max Utility Charging Current Options inquiry",
+        "help": " -- queries the maximum utility charging current setting of the Inverter",
+        "response_type": ResultType.MULTIVALUED,
+        "response": [[0, "Max Utility Charging Current", ResponseType.STRING, "A"]],
+        "test_responses": [b"(002 010 020 030 040 050 060 070 080 090 100 110 120\xca#\r"],
+    },
+    "QOPM": {
+        "name": "QOPM",
+        "description": "Output Mode inquiry",
+        "help": " -- queries the output mode of the Inverter (e.g. single, parallel, phase 1 of 3 etc)",
+        "response_type": ResultType.INDEXED,
+        "response": [
+            [
+                0,
+                "Output mode",
+                ResponseType.OPTION,
+                [
+                    "single machine output",
+                    "parallel output",
+                    "Phase 1 of 3 Phase output",
+                    "Phase 2 of 3 Phase output",
+                    "Phase 3 of 3 Phase output",
+                    "Phase 1 of 2 phase output",
+                    "Phase 2 of 2 phase output",
+                    "unknown output phase",
+                ],
+            ]
+        ],
+        "test_responses": [b"(0\xb9\x1c\r"],
+    },
+    "QPGS": {
+        "name": "QPGS",
+        "description": "Parallel Information inquiry",
+        "help": " -- example: QPGS1 queries the values of various metrics from instance 1 of parallel setup Inverters (numbers from 0)",
+        "response_type": ResultType.INDEXED,
+        "response": [
+            [0, "Parallel instance number", ResponseType.OPTION, ["Not valid", "valid"]],
+            [1, "Serial number", ResponseType.BYTES, ""],
+            [
+                2,
+                "Work mode",
+                ResponseType.STR_KEYED,
+                {
+                    "P": "Power On Mode",
+                    "S": "Standby Mode",
+                    "L": "Line Mode",
+                    "B": "Battery Mode",
+                    "F": "Fault Mode",
+                    "H": "Power Saving Mode",
+                },
+            ],
+            [
+                3,
+                "Fault code",
+                ResponseType.STR_KEYED,
+                {
+                    "00": "No fault",
+                    "01": "Fan is locked",
+                    "02": "Over temperature",
+                    "03": "Battery voltage is too high",
+                    "04": "Battery voltage is too low",
+                    "05": "Output short circuited or Over temperature",
+                    "06": "Output voltage is too high",
+                    "07": "Over load time out",
+                    "08": "Bus voltage is too high",
+                    "09": "Bus soft start failed",
+                    "11": "Main relay failed",
+                    "51": "Over current inverter",
+                    "52": "Bus soft start failed",
+                    "53": "Inverter soft start failed",
+                    "54": "Self-test failed",
+                    "55": "Over DC voltage on output of inverter",
+                    "56": "Battery connection is open",
+                    "57": "Current sensor failed",
+                    "58": "Output voltage is too low",
+                    "60": "Inverter negative power",
+                    "71": "Parallel version different",
+                    "72": "Output circuit failed",
+                    "80": "CAN communication failed",
+                    "81": "Parallel host line lost",
+                    "82": "Parallel synchronized signal lost",
+                    "83": "Parallel battery voltage detect different",
+                    "84": "Parallel Line voltage or frequency detect different",
+                    "85": "Parallel Line input current unbalanced",
+                    "86": "Parallel output setting different",
+                },
+            ],
+            [4, "Grid voltage", ResponseType.FLOAT, "V"],
+            [5, "Grid frequency", ResponseType.FLOAT, "Hz"],
+            [6, "AC output voltage", ResponseType.FLOAT, "V"],
+            [7, "AC output frequency", ResponseType.FLOAT, "Hz"],
+            [8, "AC output apparent power", ResponseType.INT, "VA"],
+            [9, "AC output active power", ResponseType.INT, "W"],
+            [10, "Load percentage", ResponseType.INT, "%"],
+            [11, "Battery voltage", ResponseType.FLOAT, "V"],
+            [12, "Battery charging current", ResponseType.INT, "A"],
+            [13, "Battery capacity", ResponseType.INT, "%"],
+            [14, "PV Input Voltage", ResponseType.FLOAT, "V"],
+            [15, "Total charging current", ResponseType.INT, "A"],
+            [16, "Total AC output apparent power", ResponseType.INT, "VA"],
+            [17, "Total output active power", ResponseType.INT, "W"],
+            [18, "Total AC output percentage", ResponseType.INT, "%"],
+            [
+                19,
+                "Inverter Status",
+                ResponseType.FLAGS,
+                [
+                    "Is SCC OK",
+                    "Is AC Charging",
+                    "Is SCC Charging",
+                    "Is Battery Over Voltage",
+                    "Is Battery Under Voltage",
+                    "Is Line Lost",
+                    "Is Load On",
+                    "Is Configuration Changed",
+                ],
+            ],
+            [
+                20,
+                "Output mode",
+                ResponseType.OPTION,
+                [
+                    "single machine",
+                    "parallel output",
+                    "Phase 1 of 3 phase output",
+                    "Phase 2 of 3 phase output",
+                    "Phase 3 of 3 phase output",
+                    "Phase 1 of 2 phase output",
+                    "Phase 2 of 2 phase output",
+                    "Unknown Output Mode",
+                ],
+            ],
+            [
+                21,
+                "Charger source priority",
+                ResponseType.OPTION,
+                ["Utility first", "Solar first", "Solar + Utility", "Solar only"],
+            ],
+            [22, "Max charger current", ResponseType.INT, "A"],
+            [23, "Max charger range", ResponseType.INT, "A"],
+            [24, "Max AC charger current", ResponseType.INT, "A"],
+            [25, "PV input current", ResponseType.INT, "A"],
+            [26, "Battery discharge current", ResponseType.INT, "A"],
+            [27, "Unknown float", ResponseType.FLOAT, ""],
+            [28, "Unknown flags?", ResponseType.STRING, ""],
+        ],
+        "test_responses": [
+            b"(1 92931701100510 B 00 000.0 00.00 230.6 50.00 0275 0141 005 51.4 001 100 083.3 002 00574 00312 003 10100110 1 2 060 120 10 04 000\xcc#\r",
+            b"(1 92912102100033 B 00 000.0 00.00 120.1 59.99 0048 0000 000 53.1 000 059 000.0 000 00154 00016 000 00000110 7 1 060 120 030 00 000 000.0 00\xe7c\r",
+            b"QPGS0?\xda\r",
+        ],
+        "regex": "QPGS(\\d+)$",
+    },
+    "QPI": {
+        "name": "QPI",
+        "description": "Protocol ID inquiry",
+        "help": " -- queries the device protocol ID. e.g. PI30 for HS series",
+        "response_type": ResultType.INDEXED,
+        "response": [[0, "Protocol Id", ResponseType.BYTES, ""]],
+        "test_responses": [b"(PI30\x9a\x0b\r"],
+    },
+    "QPIz": { # Question: is this a typo? Duplicate of QPI?
+        "name": "QPIz",
+        "description": "Protocol ID inquiry",
+        "help": " -- queries the device protocol ID. e.g. PI30 for HS series",
+        "response_type": ResultType.INDEXED,
+        "response": [[0, "Protocol ID", ResponseType.BYTES, ""]],
+        "test_responses": [b"(PI30\x9a\x0b\r"],
+    },
+    "QPIGS": {
+        "name": "QPIGS",
+        "description": "General Status Parameters inquiry",
+        "help": " -- queries the value of various metrics from the Inverter",
+        "response_type": ResultType.INDEXED,
+        "response": [
+            [
+                0,
+                "AC Input Voltage",
+                ResponseType.FLOAT,
+                "V",
+                {"icon": "mdi:transmission-tower-export", "device-class": "voltage"},
+            ],
+            [1, "AC Input Frequency", ResponseType.FLOAT, "Hz", {"icon": "mdi:current-ac", "device-class": "frequency"}],
+            [2, "AC Output Voltage", ResponseType.FLOAT, "V", {"icon": "mdi:power-plug", "device-class": "voltage"}],
+            [3, "AC Output Frequency", ResponseType.FLOAT, "Hz", {"icon": "mdi:current-ac", "device-class": "frequency"}],
+            [4, "AC Output Apparent Power", ResponseType.INT, "VA", {"icon": "mdi:power-plug", "device-class": "apparent_power"}],
+            [
+                5,
+                "AC Output Active Power",
+                ResponseType.INT,
+                "W",
+                {"icon": "mdi:power-plug", "device-class": "power", "state_class": "measurement"},
+            ],
+            [6, "AC Output Load", ResponseType.INT, "%", {"icon": "mdi:brightness-percent"}],
+            [7, "BUS Voltage", ResponseType.INT, "V", {"icon": "mdi:details", "device-class": "voltage"}],
+            [8, "Battery Voltage", ResponseType.FLOAT, "V", {"icon": "mdi:battery-outline", "device-class": "voltage"}],
+            [9, "Battery Charging Current", ResponseType.INT, "A", {"icon": "mdi:current-dc", "device-class": "current"}],
+            [10, "Battery Capacity", ResponseType.INT, "%", {"device-class": "battery"}],
+            [
+                11,
+                "Inverter Heat Sink Temperature",
+                ResponseType.INT,
+                "\u00b0C",
+                {"icon": "mdi:details", "device-class": "temperature"},
+            ],
+            [12, "PV Input Current", ResponseType.FLOAT, "A", {"icon": "mdi:solar-power", "device-class": "current"}],
+            [13, "PV Input Voltage", ResponseType.FLOAT, "V", {"icon": "mdi:solar-power", "device-class": "voltage"}],
+            [14, "Battery Voltage from SCC", ResponseType.FLOAT, "V", {"icon": "mdi:battery-outline", "device-class": "voltage"}],
+            [15, "Battery Discharge Current", ResponseType.INT, "A", {"icon": "mdi:battery-negative", "device-class": "current"}],
+            [
+                16,
+                "Device Status",
+                ResponseType.FLAGS,
+                [
+                    "Is SBU Priority Version Added",
+                    "Is Configuration Changed",
+                    "Is SCC Firmware Updated",
+                    "Is Load On",
+                    "Is Battery Voltage to Steady While Charging",
+                    "Is Charging On",
+                    "Is SCC Charging On",
+                    "Is AC Charging On",
+                ],
+            ],
+            [17, "RSV1", ResponseType.INT, "A"],
+            [18, "RSV2", ResponseType.INT, "A"],
+            [
+                19,
+                "PV Input Power",
+                ResponseType.INT,
+                "W",
+                {"icon": "mdi:solar-power", "device-class": "power", "state_class": "measurement"},
+            ],
+            [20, "Device Status2", ResponseType.FLAGS, ["Is Charging to Float", "Is Switched On", "Is Reserved"]],
+        ],
+        "test_responses": [
+            b"(000.0 00.0 230.0 49.9 0161 0119 003 460 57.50 012 100 0069 0014 103.8 57.45 00000 00110110 00 00 00856 010\x24\x8c\r",
+        ],
+    },
+    "^P007PIRI": {
+        "name": "^P007PIRI",
+        "prefix": "^P007",
+        "description": "Current Settings inquiry",
+        "help": " -- queries the current settings from the Inverter",
+        "response_type": ResultType.INDEXED,
+        "response": [
+            [0, "AC Input Voltage", ResponseType.TEN_INT, "V"],
+            [1, "AC Input Current", ResponseType.TEN_INT, "A"],
+            [2, "AC Output Voltage", ResponseType.TEN_INT, "V"],
+            [3, "AC Output Frequency", ResponseType.TEN_INT, "Hz"],
+            [4, "AC Output Current", ResponseType.TEN_INT, "A"],
+            [5, "AC Output Apparent Power", ResponseType.INT, "VA"],
+            [6, "AC Output Active Power", ResponseType.INT, "W"],
+            [7, "Battery Voltage", ResponseType.TEN_INT, "V"],
+            [8, "Battery re-charge Voltage", ResponseType.TEN_INT, "V"],
+            [9, "Battery re-discharge Voltage", ResponseType.TEN_INT, "V"],
+            [10, "Battery Under Voltage", ResponseType.TEN_INT, "V"],
+            [11, "Battery Bulk Charge Voltage", ResponseType.TEN_INT, "V"],
+            [12, "Battery Float Charge Voltage", ResponseType.TEN_INT, "V"],
+            [13, "Battery Type", ResponseType.STR_KEYED,
+                {
+                   "0":"AGM",
+                   "1":"Flooded",
+                   "2":"User",
+                },
+            ],
+            [14, "Max AC Charging Current", ResponseType.INT, "A"],
+            [15, "Max Charging Current", ResponseType.INT, "A"],
+            [16, "Input Voltage Range", ResponseType.OPTION,
+                [
+                   "Appliance",
+                   "UPS",
+                ]
+            ],
+            [17, "Output Source Priority", ResponseType.OPTION,
+                [
+                   "Solar - Utility - Battery",
+                   "Solar - Battery - Utility",
+                ]
+            ],
+            [18, "Charger Source Priority",  ResponseType.OPTION,
+                [
+                   "Solar First",
+                   "Solar + Utility",
+                   "Only solar charging permitted",
+                 ],
+            ],
+            [19, "Max Parallel Units", ResponseType.INT, "units"],
+            [20, "Machine Type", ResponseType.STR_KEYED,
+                {
+                   "0": "Off Grid",
+                   "1": "Grid Tie",
+                },
+            ],
+            [21, "Topology", ResponseType.OPTION,
+                [
+                   "transformerless",
+                   "transformer",
+                ]
+            ],
+            [22, "Output Mode", ResponseType.OPTION,
+                [
+                   "single machine output",
+                   "parallel output",
+                   "Phase 1 of 3 Phase output",
+                   "Phase 2 of 3 Phase output",
+                   "Phase 3 of 3 Phase output",
+                ],
+            ],
+            [23, "Solar power priority", ResponseType.OPTION,
+                [
+                   "Battery-Load-Utiliy + AC Charger"
+                   "Load-Battery-Utiliy",
+                ],
+            ],
+            [24, "MPPT strings", ResponseType.INT, ""],
+            [25, "Unknown flags?", ResponseType.STRING, ""],
+
+        ],
+        "test_responses": [
+            b"^D0882300,217,2300,500,217,5000,5000,480,480,530,440,570,570,2,10,070,1,1,1,9,0,0,0,0,1,00\xe1k\r",
+            # ac_input_voltage=Invalid response for AC Input Voltage: b'D0882300,217,2300,500,217,5000,5000,480,480,530,440,570,570,2,10,070,1,1,1,9,0,0,0,0,1,00'
+
+        ],
+    },
+    "QPIWS": {
+        "name": "QPIWS",
+        "description": "Warning status inquiry",
+        "help": " -- queries any active warnings flags from the Inverter",
+        "response_type": ResultType.INDEXED,
+        "response": [
+            [
+                0,
+                "Warning",
+                ResponseType.FLAGS,
+                [
+                    "",
+                    "Inverter fault",
+                    "Bus over fault",
+                    "Bus under fault",
+                    "Bus soft fail fault",
+                    "Line fail warning",
+                    "OPV short warning",
+                    "Inverter voltage too low fault",
+                    "Inverter voltage too high fault",
+                    "Over temperature fault",
+                    "Fan locked fault",
+                    "Battery voltage to high fault",
+                    "Battery low alarm warning",
+                    "Reserved",
+                    "Battery under shutdown warning",
+                    "Reserved",
+                    "Overload fault",
+                    "EEPROM fault",
+                    "Inverter over current fault",
+                    "Inverter soft fail fault",
+                    "Self test fail fault",
+                    "OP DC voltage over fault",
+                    "Bat open fault",
+                    "Current sensor fail fault",
+                    "Battery short fault",
+                    "Power limit warning",
+                    "PV voltage high warning",
+                    "MPPT overload fault",
+                    "MPPT overload warning",
+                    "Battery too low to charge warning",
+                    "",
+                    "",
+                ],
+            ]
+        ],
+        "test_responses": [b"(00000100000000001000000000000000\x56\xA6\r"],
+    },
+    "QVFW": {
+        "name": "QVFW",
+        "description": "Main CPU firmware version inquiry",
+        "help": " -- queries the main CPU firmware version",
+        "response_type": ResultType.INDEXED,
+        "response": [[0, "Main CPU firmware version", ResponseType.BYTES, ""]],
+        "test_responses": [b"(VERFW:00072.70\x53\xA7\r"],
+    },
+    "QVFW2": {
+        "name": "QVFW2",
+        "description": "Secondary CPU firmware version inquiry",
+        "help": " -- queries the secondary CPU firmware version",
+        "response_type": ResultType.INDEXED,
+        "response": [[0, "Secondary CPU firmware version", ResponseType.BYTES, ""]],
+        "test_responses": [b"(VERFW:00072.70\x53\xA7\r"],
+    },
+}
+
+
+class pi18(AbstractProtocol):
+    def __str__(self):
+        return "PI18 protocol handler"
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+        self._protocol_id = b"PI18"
+        self.add_command_definitions(QUERY_COMMANDS, "QUERY")
+        self.add_command_definitions(SETTER_COMMANDS, "SETTER")
+        self.STATUS_COMMANDS = ["PIGS"]
+        self.SETTINGS_COMMANDS = ["PIRI", "QFLAG"]
+        self.DEFAULT_COMMAND = "PI"
+        self.ID_COMMANDS = ["PI", "GMN", "MN"]
+        # log.info(f'Using protocol {self._protocol_id} with {len(self.COMMANDS)} commands')
+
+    def check_response_valid(self, result: Result):
+        # fail if no response
+        if result.raw_response is None:
+            result.is_valid = False
+            result.error = True
+            result.error_messages.append("failed validity check: response was empty")
+            return
+        # fail if dict??? not sure what this is for
+        if type(result.raw_response) is dict:
+            result.is_valid = False
+            result.error = True
+            result.error_messages.append("failed validity check: incorrect raw_response format (found dict)")
+            return
+        # fail on short responses
+        if len(result.raw_response) <= 3:
+            result.is_valid = False
+            result.error = True
+            result.error_messages.append(
+                f"failed validity check: response to short len was {len(result.raw_response)}"
+            )
+            return
+        # check crc matches the calculated one
+        calc_crc_high, calc_crc_low = crc(result.raw_response[:-3])
+        if type(result.raw_response) is str:
+            crc_high, crc_low = ord(result.raw_response[-3]), ord(result.raw_response[-2])
+        else:
+            crc_high, crc_low = result.raw_response[-3], result.raw_response[-2]
+        if [calc_crc_high, calc_crc_low] != [crc_high, crc_low]:
+            result.is_valid = False
+            result.error = True
+            result.error_messages.append(
+                f"failed validity check: response has invalid CRC - got '\\x{crc_high:02x}\\x{crc_low:02x}', calculated '\\x{calc_crc_high:02x}\\x{calc_crc_low:02x}'"
+            )
+            return
+            # if result.raw_response[-3:-1] != bytes([calc_crc_high, calc_crc_low]):
+        log.debug("CRCs match")
+        return
+
+    def get_responses(self, response) -> list:
+        """
+        Override the default get_responses as its different for PI18
+        """
+        if not response:
+            return ["No response"]
+        responses = response.split(b",")
+        if responses[0] == b"^0\x1b\xe3\r":
+            # is a reject response
+            return ["NAK"]
+        elif responses[0] == b"^1\x0b\xc2\r":
+            # is a successful acknowledgement response
+            return ["ACK"]
+
+        # Drop ^Dxxx from first response
+        responses[0] = responses[0][5:]
+        # Remove CRC of last response
+        responses[-1] = responses[-1][:-3]
+        return responses


### PR DESCRIPTION
Hi, 
I've just made my first attempts at using the Powermon. And seen that only one protocol is stored.
I started writing the PI18 protocol

Here the first PIRI Output
```
2023-10-15 11:05:04,675:INFO:__init__:main@149: config: {'debuglevel': 10, 'device': {'name': 'Inverter1', 'id': 'a123456789', 'model': 'HybridV25048', 'manufacturer': 'MPP-Solar', 'port': {'path': '/dev/hidraw0', 'type': 'usb', 'protocol': 'PI18'}}, 'commands': [{'command': '^P007PIRI', 'type': 'basic', 'trigger': None, 'outputs': [{'type': 'screen', 'format': None}]}], 'loop': 'once', 'mqttbroker': None, 'api': {'host': '0.0.0.0', 'port': 5000, 'log_level': 'info', 'announce_topic': 'powermon/announce', 'adhoc_topic': 'powermon/adhoc', 'refresh_interval': 60}, 'daemon': None}
2023-10-15 11:05:04,676:DEBUG:mqttbroker:from_config@23: mqttbroker config: None
2023-10-15 11:05:04,676:INFO:__init__:main@154: MqttBroker DISABLED
2023-10-15 11:05:04,676:DEBUG:__init__:getPortFromConfig@12: port_config: {'path': '/dev/hidraw0', 'type': 'usb', 'protocol': 'PI18'}
2023-10-15 11:05:04,676:DEBUG:__init__:getPortFromConfig@21: portType: usb
2023-10-15 11:05:04,677:DEBUG:usbport:fromConfig@17: building usb port. config:{'path': '/dev/hidraw0', 'type': 'usb', 'protocol': 'PI18'}
2023-10-15 11:05:04,677:DEBUG:__init__:get_protocol_definition@13: Protocol PI18
2023-10-15 11:05:04,683:DEBUG:__init__:main@158: Device: Inverter1, self.device_id='a123456789', self.model='HybridV25048', self.manufacturer='MPP-Solar', port: <powermon.ports.usbport.USBPort object at 0x7ff116eaf140>, commands:[]
2023-10-15 11:05:04,683:DEBUG:__init__:getOutputs@48: processing outputsConfig: [{'type': 'screen', 'format': None}]
2023-10-15 11:05:04,683:DEBUG:__init__:parseOutputConfig@68: parseOutputConfig, config: {'type': 'screen', 'format': None}
2023-10-15 11:05:04,684:DEBUG:__init__:parseOutputConfig@90: got dict type outputConfig: {'type': 'screen', 'format': None}
2023-10-15 11:05:04,684:DEBUG:__init__:getFormatfromConfig@27: getFormatfromConfig, formatConfig: None
2023-10-15 11:05:04,684:DEBUG:__init__:getFormatfromConfig@39: getFormatfromConfig, formatType: simple
2023-10-15 11:05:04,685:DEBUG:__init__:parseOutputConfig@95: got format: Format: simple
2023-10-15 11:05:04,685:DEBUG:__init__:getOutputClass@23: outputType screen
2023-10-15 11:05:04,686:DEBUG:__init__:parseOutputConfig@97: got output: <powermon.outputs.screen.Screen object at 0x7ff116eaf230>
2023-10-15 11:05:04,687:DEBUG:command:__init__@29: Command: self.code='^P007PIRI' self.full_command=None, self.type='basic', [_outs='<powermon.outputs.screen.Screen object at 0x7ff116eaf230>'], last_run='Not yet run', next_run='15 Oct 2023 11:05:04', trigger: every 60 loops togo: 0, self.command_definition=None
2023-10-15 11:05:04,687:DEBUG:abstractprotocol:get_command_definition@102: Processing command '^P007PIRI'
2023-10-15 11:05:04,687:DEBUG:abstractprotocol:get_command_definition@104: Found command ^P007PIRI in protocol b'PI18'
2023-10-15 11:05:04,687:DEBUG:device:add_command@67: added command (Command: self.code='^P007PIRI' self.full_command=None, self.type='basic', [_outs='<powermon.outputs.screen.Screen object at 0x7ff116eaf230>'], last_run='Not yet run', next_run='15 Oct 2023 11:05:04', trigger: every 60 loops togo: 0, self.command_definition=<powermon.commands.command_definition.CommandDefinition object at 0x7ff116eaddc0>), command list length: 1
2023-10-15 11:05:04,688:INFO:__init__:main@165: Device: Inverter1, self.device_id='a123456789', self.model='HybridV25048', self.manufacturer='MPP-Solar', port: <powermon.ports.usbport.USBPort object at 0x7ff116eaf140>, commands:[<powermon.commands.command.Command object at 0x7ff116eaf260>]
2023-10-15 11:05:04,688:DEBUG:daemon:from_config@34: daemon config: None
2023-10-15 11:05:04,688:DEBUG:daemon:from_config@40: daemon not configured, disabling
2023-10-15 11:05:04,688:DEBUG:daemon:__init__@54: got daemon type: disabled, keepalive: 0
2023-10-15 11:05:04,689:INFO:__init__:main@169: Daemon DISABLED
2023-10-15 11:05:04,689:DEBUG:apicoordinator:from_config@23: ApiCoordinator config: {'host': '0.0.0.0', 'port': 5000, 'log_level': 'info', 'announce_topic': 'powermon/announce', 'adhoc_topic': 'powermon/adhoc', 'refresh_interval': 60}
2023-10-15 11:05:04,689:DEBUG:apicoordinator:set_mqtt_broker@56: MqttBroker DISABLED
2023-10-15 11:05:04,689:DEBUG:apicoordinator:set_mqtt_broker@57: No mqttbroker (or it is disabled) so disabling ApiCoordinator
2023-10-15 11:05:04,690:INFO:__init__:main@175: ApiCoordinator DISABLED
2023-10-15 11:05:04,690:INFO:device:initialize@90: initializing device
2023-10-15 11:05:04,790:DEBUG:device:run@107: Running command: ^P007PIRI
2023-10-15 11:05:04,791:DEBUG:usbport:connect@36: USBPort connecting. path:/dev/hidraw0, protocol: PI18 protocol handler
2023-10-15 11:05:04,849:DEBUG:usbport:connect@39: USBPort port number $3
2023-10-15 11:05:04,850:DEBUG:abstractport:run_command@65: Command Command: self.code='^P007PIRI' self.full_command=None, self.type='basic', [_outs='<powermon.outputs.screen.Screen object at 0x7ff116eaf230>'], last_run='Not yet run', next_run='15 Oct 2023 11:05:04', trigger: every 60 loops togo: 0, self.command_definition=<powermon.commands.command_definition.CommandDefinition object at 0x7ff116eaddc0>
2023-10-15 11:05:04,851:INFO:abstractprotocol:get_full_command@78: Using protocol b'PI18' with 36 commands
2023-10-15 11:05:04,851:DEBUG:protocol_helpers:crcPI@309: Calculating CRC for b'^P007PIRI'
2023-10-15 11:05:04,851:DEBUG:protocol_helpers:crcPI@359: Generated CRC 0xee 0x38 0xee38
2023-10-15 11:05:04,852:DEBUG:abstractprotocol:get_full_command@84: full command: b'^P007PIRI\xee8\r'
2023-10-15 11:05:04,852:DEBUG:result:__init__@30: Result: Result: self.is_valid=False, self.error=False - self.error_messages=[], self.raw_response=None, self.responses=[]
2023-10-15 11:05:04,853:DEBUG:usbport:send_and_receive@59: length of to_send: 12
2023-10-15 11:05:04,853:DEBUG:usbport:send_and_receive@68: multiple chunk send
2023-10-15 11:05:04,853:DEBUG:usbport:send_and_receive@75: sending chunk: b'^P007PIR'
2023-10-15 11:05:04,907:DEBUG:usbport:send_and_receive@75: sending chunk: b'I\xee8\r\x00\x00\x00\x00'
2023-10-15 11:05:07,013:DEBUG:usbport:send_and_receive@94: usb response was: b'^D0882300,217,2300,500,217,5000,5000,480,480,530,440,570,570,2,10,070,1,1,1,9,0,0,0,0,1,00\xe1k\r'
2023-10-15 11:05:07,015:DEBUG:abstractport:run_command@74: after send_and_receive Result: self.is_valid=False, self.error=False - self.error_messages=[], self.raw_response=b'^D0882300,217,2300,500,217,5000,5000,480,480,530,440,570,570,2,10,070,1,1,1,9,0,0,0,0,1,00\xe1k\r', self.responses=[]
2023-10-15 11:05:07,016:INFO:abstractprotocol:decode@146: result.raw_response passed to decode: b'^D0882300,217,2300,500,217,5000,5000,480,480,530,440,570,570,2,10,070,1,1,1,9,0,0,0,0,1,00\xe1k\r'
2023-10-15 11:05:07,017:DEBUG:protocol_helpers:crcPI@309: Calculating CRC for b'^D0882300,217,2300,500,217,5000,5000,480,480,530,440,570,570,2,10,070,1,1,1,9,0,0,0,0,1,00'
2023-10-15 11:05:07,019:DEBUG:protocol_helpers:crcPI@359: Generated CRC 0xe1 0x6b 0xe16b
2023-10-15 11:05:07,020:DEBUG:pi18:check_response_valid@821: CRCs match
2023-10-15 11:05:07,022:DEBUG:abstractprotocol:decode@169: trimmed and split responses: [<powermon.commands.response.Response object at 0x7ff116ecc110>, <powermon.commands.response.Response object at 0x7ff116ecc170>, <powermon.commands.response.Response object at 0x7ff116ecc1d0>, <powermon.commands.response.Response object at 0x7ff116ecc230>, <powermon.commands.response.Response object at 0x7ff116ecc2c0>, <powermon.commands.response.Response object at 0x7ff116ecc320>, <powermon.commands.response.Response object at 0x7ff116ecc380>, <powermon.commands.response.Response object at 0x7ff116ecc3e0>, <powermon.commands.response.Response object at 0x7ff116ecc440>, <powermon.commands.response.Response object at 0x7ff116ecc4a0>, <powermon.commands.response.Response object at 0x7ff116ecc500>, <powermon.commands.response.Response object at 0x7ff116ecc560>, <powermon.commands.response.Response object at 0x7ff116ecc5c0>, <powermon.commands.response.Response object at 0x7ff116ecc5f0>, <powermon.commands.response.Response object at 0x7ff116ecc650>, <powermon.commands.response.Response object at 0x7ff116ecc6b0>, <powermon.commands.response.Response object at 0x7ff116ecc6e0>, <powermon.commands.response.Response object at 0x7ff116ecc710>, <powermon.commands.response.Response object at 0x7ff116ecc740>, <powermon.commands.response.Response object at 0x7ff116ecc7d0>, <powermon.commands.response.Response object at 0x7ff116ecc800>, <powermon.commands.response.Response object at 0x7ff116ecc830>, <powermon.commands.response.Response object at 0x7ff116ecc860>, <powermon.commands.response.Response object at 0x7ff116ecc890>, <powermon.commands.response.Response object at 0x7ff116ecc8f0>, <powermon.commands.response.Response object at 0x7ff116ecc950>]
2023-10-15 11:05:07,023:DEBUG:device:run@123: Using Output: <powermon.outputs.screen.Screen object at 0x7ff116eaf230>
2023-10-15 11:05:07,024:INFO:screen:process@23: Using output sender: screen
2023-10-15 11:05:07,026:DEBUG:screen:process@24: formatter: Format: simple
2023-10-15 11:05:07,027:INFO:device:finalize@94: finalizing device
2023-10-15 11:05:07,028:DEBUG:usbport:disconnect@46: USBPort disconnecting 3
2023-10-15 11:05:07,030:DEBUG:mqttbroker:stop@114: Stopping mqttbroker connection
ac_input_voltage=230.0V
ac_input_current=21.7A
ac_output_voltage=230.0V
ac_output_frequency=50.0Hz
ac_output_current=21.7A
ac_output_apparent_power=5000VA
ac_output_active_power=5000W
battery_voltage=48.0V
battery_re-charge_voltage=48.0V
battery_re-discharge_voltage=53.0V
battery_under_voltage=44.0V
battery_bulk_charge_voltage=57.0V
battery_float_charge_voltage=57.0V
battery_type=User
max_ac_charging_current=10A
max_charging_current=70A
input_voltage_range=UPS
output_source_priority=Solar - Battery - Utility
charger_source_priority=Solar + Utility
max_parallel_units=9units
machine_type=Off Grid
topology=transformerless
output_mode=single machine output
solar_power_priority=Battery-Load-Utiliy + AC ChargerLoad-Battery-Utiliy
mppt_strings=1
unknown_flags?=00
```
