### PR TITLE
feat: Introduce the `prom_push` output

### DIFF
--- a/mppsolar/__init__.py
+++ b/mppsolar/__init__.py
@@ -153,6 +153,14 @@ def main():
         default="mppsolar",
     )
     parser.add_argument(
+        "--pushurl",
+        help=(
+            "Any server used to send data to (PushGateway for Prometheus, for instance), "
+            "(default: http://localhost:9091/metrics/job/pushgateway)"
+        ),
+        default="http://localhost:9091/metrics/job/pushgateway",
+    )
+    parser.add_argument(
         "-c",
         "--command",
         nargs="?",
@@ -261,6 +269,7 @@ def main():
     excl_filter = args.exclfilter
     keep_case = args.keepcase
     mqtt_topic = args.mqtttopic
+    push_url = args.pushurl
 
     _commands = []
     # Initialize Daemon
@@ -318,6 +327,7 @@ def main():
             postgres_url = config[section].get("postgres_url", fallback=None)
             mongo_url = config[section].get("mongo_url", fallback=None)
             mongo_db = config[section].get("mongo_db", fallback=None)
+            push_url = config[section].get("push_url", fallback=push_url)
             #
             device_class = get_device_class(_type)
             log.debug(f"device_class {device_class}")
@@ -334,6 +344,7 @@ def main():
                 postgres_url=postgres_url,
                 mongo_url=mongo_url,
                 mongo_db=mongo_db,
+                push_url=push_url,
             )
             # build array of commands
             commands = _command.split("#")
@@ -372,6 +383,7 @@ def main():
             udp_port=udp_port,
             mongo_url=mongo_url,
             mongo_db=mongo_db,
+            push_url=push_url,
         )
         #
 
@@ -440,6 +452,7 @@ def main():
                     postgres_url=postgres_url,
                     mongo_url=mongo_url,
                     mongo_db=mongo_db,
+                    push_url=push_url,
                     # mqtt_port=mqtt_port,
                     # mqtt_user=mqtt_user,
                     # mqtt_pass=mqtt_pass,

--- a/mppsolar/outputs/prom.py
+++ b/mppsolar/outputs/prom.py
@@ -9,7 +9,7 @@ log = logging.getLogger("prom")
 
 class prom(baseoutput):
     def __str__(self):
-        return "outputs Node exporter prometheus format to standard out"
+        return "outputs Node exporter Prometheus format to standard out"
 
     def __init__(self, *args, **kwargs) -> None:
         log.debug(f"processor.value __init__ kwargs {kwargs}")
@@ -63,8 +63,7 @@ class prom(baseoutput):
 
         # build data to display
         displayData = {}
-        for key in data:
-            _values = data[key]
+        for key, _values in data.items():
             # remove spaces
             if remove_spaces:
                 key = key.replace(" ", "_")
@@ -75,11 +74,15 @@ class prom(baseoutput):
                 displayData[key] = _values
         log.debug(f"displayData: {displayData}")
 
-        # print data
-        print(f'machine_role{{role="mpp_solar"}} 1')
+        output = f'machine_role{{role="mpp_solar"}} 1\n'
         for key in displayData:
             value = displayData[key][0]
             if isinstance(value, str):
-                print(f'mpp_solar_{key}{{inverter="{name}",device="{dev}",cmd="{cmd}",myStr="{value}"}} 1')
+                output += f'mpp_solar_{key}{{inverter="{name}",device="{dev}",cmd="{cmd}",myStr="{value}"}} 1\n'
             else:
-                print(f'mpp_solar_{key}{{inverter="{name}",device="{dev}",cmd="{cmd}"}} {value}')
+                output += f'mpp_solar_{key}{{inverter="{name}",device="{dev}",cmd="{cmd}"}} {value}\n'
+
+        self.handle_output(output)
+
+    def handle_output(self, content: str) -> None:
+        print(content.rstrip())

--- a/mppsolar/outputs/prom_push.py
+++ b/mppsolar/outputs/prom_push.py
@@ -1,0 +1,26 @@
+import logging
+
+import requests
+
+from .prom import prom
+from ..helpers import get_kwargs
+
+log = logging.getLogger("prom")
+
+
+class prom_push(prom):
+    push_url = ""
+
+    def __str__(self):
+        return "pushes Node exporter Prometheus format to PushGateway"
+
+    def output(self, *args, **kwargs):
+        # We override the method only to get the PushGateway URL from the config
+        self.push_url = kwargs["push_url"]
+
+        return super().output(*args, **kwargs)
+
+    def handle_output(self, content: str) -> None:
+        with requests.post(self.push_url, data=content) as req:
+            log.debug(f"POST'ed data to PushGateway {self.push_url!r}: {req=}")
+    

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ fastapi-mqtt = ">=1.1"
 # jinja2 = {version = ">=3.0.0", optional = true}
 # fastapi-mqtt = {version = ">=1.0.7", optional = true}
 sqlalchemy = "^2.0.15"
+requests = ">=2.31.0"
 
 [tool.poetry.extras]
 ble = ["bluepy", "bleak"]


### PR DESCRIPTION
It will push metrics to a running PushGateway, and Prometheus will need to be configured to pull metrcis from there.

The default URL can be changed via the `push_url` from the config file, example:

```ini
[Inverter_1]
port=/dev/ttyUSB0
protocol=PI30M045
command=QPGS0
outputs=prom_push
push_url=http://example.org/metrics/job/foo
```

Or via the `--pushurl` CLI argument.

On the Prometheus side, add a new scrape config:

```yaml
scrape_configs:
  # (...)

  - job_name: pushgateway
    honor_labels: true
    static_configs:
      - targets:
          - localhost:9091
```

And that's it!

Closes #434.