### PR TITLE
feat: Use extras to install specific dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ Currently has support for:
 
 ## Install ##
 - `pip install mppsolar` (minimal install), or
-- `pip install mppsolar[ble]` (install including BLE support aka jkbms), or
+- `pip install mppsolar[api]` (install server stuff), or
+- `pip install mppsolar[ble]` (for Bluetooth support aka jkbms), or
+- `pip install mppsolar[mongo]` (for MongoDB output), or
+- `pip install mppsolar[pgsql]` (for PostgreSQL output), or
+- `pip install mppsolar[push]` (for Pometheus PushGateway output), or
+- `pip install mppsolar[systemd]` (for `--daemon` on Linux), or
 - `docker pull jblance/mppsolar:latest` (docker install)
 
 

--- a/mppsolar/__init__.py
+++ b/mppsolar/__init__.py
@@ -257,7 +257,13 @@ def main():
     if args.daemon:
         import time
 
-        import systemd.daemon
+        try:
+            import systemd.daemon
+        except ImportError:
+            print("You are missing dependencies in order to be able to use the --daemon flag.")
+            print("To install them, use that command:")
+            print("    python -m pip install 'mppsolar[systemd]'")
+            exit(1)
 
         # Tell systemd that our service is ready
         systemd.daemon.notify("READY=1")

--- a/mppsolar/inout/esp32io.py
+++ b/mppsolar/inout/esp32io.py
@@ -1,6 +1,7 @@
 import logging
-from machine import UART
 import time
+
+from machine import UART
 
 from .baseio import BaseIO
 from ..helpers import get_kwargs

--- a/mppsolar/inout/jkbleio.py
+++ b/mppsolar/inout/jkbleio.py
@@ -1,6 +1,11 @@
-from bluepy import btle
 import logging
 
+try:
+    from bluepy import btle
+except ImportError:
+    print("You are missing dependencies in order to be able to use that output.")
+    print("To install them, use that command:")
+    print("    python -m pip install 'mppsolar[ble]'")
 
 from .baseio import BaseIO
 from ..helpers import get_kwargs

--- a/mppsolar/inout/mqttio.py
+++ b/mppsolar/inout/mqttio.py
@@ -5,9 +5,6 @@ import time
 
 import paho.mqtt.client as mqttc
 
-# import paho.mqtt.publish as publish
-# import paho.mqtt.subscribe as subscribe
-
 from ..helpers import get_kwargs
 from .baseio import BaseIO
 

--- a/mppsolar/outputs/mongo.py
+++ b/mppsolar/outputs/mongo.py
@@ -2,12 +2,17 @@ import datetime
 import logging
 import re
 
-import pymongo as pymongo
+try:
+    import pymongo as pymongo
+except ImportError:
+    print("You are missing dependencies in order to be able to use that output.")
+    print("To install them, use that command:")
+    print("    python -m pip install 'mppsolar[mongo]'")
+    pymongo = None
 
 from . import to_json
 from .baseoutput import baseoutput
 from ..helpers import get_kwargs
-# from ..helpers import key_wanted
 
 log = logging.getLogger("mongo")
 
@@ -20,6 +25,9 @@ class mongo(baseoutput):
         log.debug(f"__init__: kwargs {kwargs}")
 
     def output(self, *args, **kwargs):
+        if not pymongo:
+            return
+
         data = get_kwargs(kwargs, "data")
         # tag = get_kwargs(kwargs, "tag")
         keep_case = get_kwargs(kwargs, "keep_case")

--- a/mppsolar/outputs/prom_push.py
+++ b/mppsolar/outputs/prom_push.py
@@ -1,6 +1,12 @@
 import logging
 
-import requests
+try:
+    import requests
+except ImportError:
+    print("You are missing dependencies in order to be able to use that output.")
+    print("To install them, use that command:")
+    print("    python -m pip install 'mppsolar[push]'")
+    requests = None
 
 from .prom import prom
 from ..helpers import get_kwargs
@@ -21,6 +27,9 @@ class prom_push(prom):
         return super().output(*args, **kwargs)
 
     def handle_output(self, content: str) -> None:
+        if not requests:
+            return
+
         with requests.post(self.push_url, data=content) as req:
             log.debug(f"POST'ed data to PushGateway {self.push_url!r}: {req=}")
     

--- a/mppsolar/protocols/abstractprotocol.py
+++ b/mppsolar/protocols/abstractprotocol.py
@@ -2,10 +2,8 @@ import abc
 import calendar  # noqa: F401
 import logging
 import re
-from datetime import datetime
 from typing import Tuple
 from pydantic import BaseModel
-# from powermon.dto.protocolDTO import ProtocolDTO
 
 from ..helpers import get_resp_defn, get_value
 from .protocol_helpers import BigHex2Short, BigHex2Float  # noqa: F401

--- a/mppsolar/protocols/daly.py
+++ b/mppsolar/protocols/daly.py
@@ -4,8 +4,6 @@ from typing import Tuple
 from .abstractprotocol import AbstractProtocol
 from .protocol_helpers import crc8 as dalyChecksum
 
-# from .pi30 import COMMANDS
-
 log = logging.getLogger("daly")
 
 # (AAA BBB CCC DDD EEE

--- a/mppsolar/protocols/daly40.py
+++ b/mppsolar/protocols/daly40.py
@@ -2,8 +2,6 @@ import logging
 
 from .daly import daly
 
-# from .pi30 import COMMANDS
-
 log = logging.getLogger("daly40")
 
 # (AAA BBB CCC DDD EEE

--- a/mppsolar/protocols/pi16.py
+++ b/mppsolar/protocols/pi16.py
@@ -2,8 +2,6 @@ import logging
 
 from .abstractprotocol import AbstractProtocol
 
-# from .pi30 import COMMANDS
-
 log = logging.getLogger("pi16")
 
 # (AAA BBB CCC DDD EEE

--- a/mppsolar/protocols/pi17.py
+++ b/mppsolar/protocols/pi17.py
@@ -2,10 +2,6 @@ import logging
 
 from .abstractprotocol import AbstractProtocol
 
-# from .protocol_helpers import crcPI as crc
-
-# from .pi30 import COMMANDS
-
 log = logging.getLogger("pi17")
 
 QUERY_COMMANDS = {

--- a/mppsolar/protocols/pi18.py
+++ b/mppsolar/protocols/pi18.py
@@ -3,8 +3,6 @@ import logging
 from .abstractprotocol import AbstractProtocol
 from .protocol_helpers import crcPI as crc
 
-# from .pi30 import COMMANDS
-
 log = logging.getLogger("pi18")
 
 COMMANDS = {

--- a/mppsolar/protocols/pi30m044.py
+++ b/mppsolar/protocols/pi30m044.py
@@ -1,5 +1,4 @@
 import logging
-#import datetime.datetime
 
 from .pi30max import pi30max
 

--- a/mppsolar/protocols/protocol_helpers.py
+++ b/mppsolar/protocols/protocol_helpers.py
@@ -2,7 +2,6 @@
 import logging
 import math
 
-# from binascii import unhexlify
 from struct import unpack
 
 log = logging.getLogger("protocol_helpers")

--- a/mppsolar/protocols/ved.py
+++ b/mppsolar/protocols/ved.py
@@ -4,8 +4,6 @@ from typing import Tuple
 from .abstractprotocol import AbstractProtocol
 from .protocol_helpers import vedHexChecksum
 
-# from .pi30 import COMMANDS
-
 log = logging.getLogger("ved")
 
 # (AAA BBB CCC DDD EEE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,21 +13,34 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.00"
+paho-mqtt = ">=1.6"
 pyserial = ">3"
 pydantic = ">=1.8.0"
 
 # Extra dependencies
-fastapi = { version = ">=0.68.0", extras = ["api"] }
-fastapi-mqtt = { version = ">=1.1", extras = ["api"] }
-sqlalchemy = { version = "^2.0.15", extras = ["api"] }
-uvicorn = { version = ">=0.15.0", extras = ["api"] }
-bleak = { version = "^0.20.2", extras = ["ble"] }
-bluepy = { version = "^1.3.0", extras = ["ble"] }
-paho-mqtt = { version = ">=1.6", extras = ["mqtt"] }
-requests = { version = ">=2.31.0", extras = ["push"] }
-PyYAML = { version = ">=62.31.0", extras = ["powermon"] }
-strenum = { version = "^0.4.1", extras = ["powermon"] }
-systemd = { version = ">=0.17.1", extras = ["systemd"] }
+bleak = { version = "^0.20.2", optional = true }
+bluepy = { version = "^1.3.0", optional = true }
+cysystemd = { version = ">=1.6.0", optional = true }
+fastapi = { version = ">=0.68.0", optional = true }
+fastapi-mqtt = { version = ">=1.1", optional = true }
+# paho-mqtt = { version = ">=1.6", optional = true }
+pymongo = { version = ">=4.6.1", optional = true }
+psycopg2-binary = { version = ">=2.9.9", optional = true }
+PyYAML = { version = ">=6", optional = true }
+requests = { version = ">=2.31.0", optional = true }
+sqlalchemy = { version = "^2.0.15", optional = true }
+strenum = { version = "^0.4.1", optional = true }
+uvicorn = { version = ">=0.15.0", optional = true }
+
+[tool.poetry.extras]
+api = ["fastapi", "fastapi-mqtt", "sqlalchemy", "uvicorn"]
+ble = ["bleak", "bluepy"]
+# mqtt = ["paho-mqtt"]
+mongo = ["pymongo"]
+pgsql = ["psycopg2-binary"]
+powermon = ["PyYAML", "strenum"]
+push = ["requests"]
+systemd = ["cysystemd"]
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,35 +5,29 @@ description = "Package to communicate with Solar inverters and BMSs"
 authors = ["John Blance"]
 readme = "README.md"
 packages = [
-            {include = "mppsolar"},
-            {include = "powermon"},
-            {include = "api"},
-            {include = "powermon_api"},
-            ]
+    {include = "mppsolar"},
+    {include = "powermon"},
+    {include = "api"},
+    {include = "powermon_api"},
+]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.00"
 pyserial = ">3"
-paho-mqtt = ">=1.6"
-PyYAML = ">=6"
 pydantic = ">=1.8.0"
-strenum = "^0.4.10"
-bluepy = {version = "^1.3.0", optional = true}
-bleak = {version = "^0.20.2", optional = true}
-fastapi = ">=0.68.0"
-uvicorn = ">=0.15.0"
-jinja2 = ">=3.0.0"
-fastapi-mqtt = ">=1.1"
-# fastapi = {version = ">=0.68.0", optional = true}
-# uvicorn = {version = ">=0.15.0", optional = true}
-# jinja2 = {version = ">=3.0.0", optional = true}
-# fastapi-mqtt = {version = ">=1.0.7", optional = true}
-sqlalchemy = "^2.0.15"
-requests = ">=2.31.0"
 
-[tool.poetry.extras]
-ble = ["bluepy", "bleak"]
-#api = ["fastapi", "uvicorn", "jinja2", "fastapi-mqtt"]
+# Extra dependencies
+fastapi = { version = ">=0.68.0", extras = ["api"] }
+fastapi-mqtt = { version = ">=1.1", extras = ["api"] }
+sqlalchemy = { version = "^2.0.15", extras = ["api"] }
+uvicorn = { version = ">=0.15.0", extras = ["api"] }
+bleak = { version = "^0.20.2", extras = ["ble"] }
+bluepy = { version = "^1.3.0", extras = ["ble"] }
+paho-mqtt = { version = ">=1.6", extras = ["mqtt"] }
+requests = { version = ">=2.31.0", extras = ["push"] }
+PyYAML = { version = ">=62.31.0", extras = ["powermon"] }
+strenum = { version = "^0.4.1", extras = ["powermon"] }
+systemd = { version = ">=0.17.1", extras = ["systemd"] }
 
 [tool.poetry.group.dev]
 optional = true

--- a/tests/mppsolar_tests/test_outputs.py
+++ b/tests/mppsolar_tests/test_outputs.py
@@ -1,0 +1,23 @@
+import importlib
+import unittest
+from pathlib import Path
+
+HERE = Path( __file__).parent
+OUTPUTS_DIR = HERE.parent.parent / "mppsolar" / "outputs"
+OUTPUTS = sorted(
+    file.stem for file in OUTPUTS_DIR.glob("*.py")
+    if file.stem != "__init__"
+)
+
+
+class testOutputs(unittest.TestCase):
+
+    def test_outputs_count(self):
+        assert len(OUTPUTS) == 23, len(OUTPUTS)
+
+    def test_outputs_init(self):
+        for output in OUTPUTS:
+            module_cls = importlib.import_module(f"mppsolar.outputs.{output}", ".")
+            cls = getattr(module_cls, output)()
+            assert cls
+            assert type(cls).__name__ == output

--- a/tests/mppsolar_tests/test_protocols.py
+++ b/tests/mppsolar_tests/test_protocols.py
@@ -1,0 +1,25 @@
+import importlib
+import unittest
+from pathlib import Path
+
+HERE = Path( __file__).parent
+PROTOCOLS_DIR = HERE.parent.parent / "mppsolar" / "protocols"
+PROTOCOLS = sorted(
+    file.stem for file in PROTOCOLS_DIR.glob("*.py")
+    if "init" not in file.stem
+    and "abstract" not in file.stem
+    and "protocol" not in file.stem
+)
+
+
+class testProtocols(unittest.TestCase):
+
+    def test_protocols_count(self):
+        assert len(PROTOCOLS) == 25, len(PROTOCOLS)
+
+    def test_protocols_init(self):
+        for protocol in PROTOCOLS:
+            module_cls = importlib.import_module(f"mppsolar.protocols.{protocol}", ".")
+            cls = getattr(module_cls, protocol)()
+            assert cls
+            assert type(cls).__name__ == protocol


### PR DESCRIPTION
The only missing piece is MQTT, it is way to intriqued everywhere.
So for now, the `paho-mqtt` dependency will be installed by default.

At some point, it will be cool to be able to get rid of it and install it via:

```shell
$ python -m pip install 'mppsolar[mqtt]'
```

Also, I added very primary tests to see if all protocols and outputs can be
imported even when a depedency is missing.

A proper message will be printed
in that case (except for `esp32io.py` and the `machine` import, I guss this is very specific?).