### PR TITLE
feat: allow to set `mqtt_topic` from the config file

### DIFF
--- a/mppsolar/__init__.py
+++ b/mppsolar/__init__.py
@@ -315,6 +315,7 @@ def main():
             mongo_url = config[section].get("mongo_url", fallback=None)
             mongo_db = config[section].get("mongo_db", fallback=None)
             push_url = config[section].get("push_url", fallback=push_url)
+            mqtt_topic = config[section].get("mqtt_topic", fallback=mqtt_topic)
             #
             device_class = get_device_class(_type)
             log.debug(f"device_class {device_class}")


### PR DESCRIPTION
Example:

```ini
[SETUP]
pause=60

[Inverter_1]
port=/dev/ttyUSB0
protocol=PI30M044
command=QPGS0#Q1#QPIGS
outputs=influx2_mqtt
mqtt_topic=inverter1
```

My need is to be able to filter, from Grafana, on the inverter number (via the `mqtt_topic` option), and the command (automatically set). At the beginning I was only using `tag=inverter1`, but then I won't be able to select the correct information when it is delivered twice by different commands.

On the Grafana side, with that PR, I should be able to filter like:
```
|> filter: r.topic == "inverter1" and r.command == "QPGS0"
|> filter: r._field == "pv1_charging_power"
```

If there is another solution, I am open to ideas :)