### PR TITLE
fixed crc calculation for axpert inverters

### DIFF
--- a/mppsolar/protocols/protocol_helpers.py
+++ b/mppsolar/protocols/protocol_helpers.py
@@ -347,9 +347,9 @@ def crcPI(data_bytes):
     crc_low = crc & 0xFF
     crc_high = (crc >> 8) & 0xFF
 
-    if crc_low == 0x28 or crc_low == 0x0D or crc_low == 0x0A:
+    if crc_low == 0x28 or crc_low == 0x0D or crc_low == 0x0A or crc_low == 0x00:
         crc_low += 1
-    if crc_high == 0x28 or crc_high == 0x0D or crc_high == 0x0A:
+    if crc_high == 0x28 or crc_high == 0x0D or crc_high == 0x0A or crc_high == 0x00:
         crc_high += 1
 
     crc = crc_high << 8


### PR DESCRIPTION
I noticed that sometimes the commands sent to my inverter (Axpert VM IV) timeout. I execute the QED[YYYYMMDD] command daily, many times per day to monitor the PV production per day and on some days every call will timeout. I tracked it to the CRC as one of the bytes or the CRC for those days equals 0x00. Incrementing this value to 0x01 will solve the problem.