### PR TITLE
Use wildcards for port definition

### DIFF
--- a/powermon/commands/command_definition.py
+++ b/powermon/commands/command_definition.py
@@ -38,6 +38,7 @@ class CommandDefinition:
         self.command_type = None
         self.command_code : str = None
         self.construct: cs.Construct = None
+        self.construct_min_response = None
 
     @classmethod
     def from_config(cls, protocol_dictionary : dict) -> "CommandDefinition":
@@ -69,6 +70,7 @@ class CommandDefinition:
         _command_definition.command_type = protocol_dictionary.get("command_type")
         _command_definition.command_code = protocol_dictionary.get("command_code")
         _command_definition.construct = protocol_dictionary.get("construct")
+        _command_definition.construct_min_response = protocol_dictionary.get("construct_min_response")
         return _command_definition
 
     def to_dto(self) -> CommandDefinitionDTO:

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -58,7 +58,7 @@ class SerialPort(AbstractPort):
                 for _path in paths:
                     print(f"checking path: {_path} to see if it matches {identifier}")
                     self.path = _path
-                    res = self.send_and_receive(command=command)
+                    res = asyncio.run(self.send_and_receive(command=command))
                     print(res)
                     
                     # self.send_and_receive()

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -58,6 +58,7 @@ class SerialPort(AbstractPort):
                 for _path in paths:
                     print(f"checking path: {_path} to see if it matches {identifier}")
                     self.path = _path
+                    asyncio.run(self.connect())
                     res = asyncio.run(self.send_and_receive(command=command))
                     print(res)
                     

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -69,7 +69,7 @@ class SerialPort(AbstractPort):
                     # print(res.readings[0].data_value)
                     # print(res.readings[0].data_value == identifier)
                     if res.readings[0].data_value == identifier:
-                        log.debug("SUCCESS: path: %s matches for identifier: %s", _path, identifier)
+                        log.info("SUCCESS: path: %s matches for identifier: %s", _path, identifier)
                         return
                 raise ConfigError(f"Multiple paths - none of {paths} match {identifier}")
         # end of multi-path logic

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -9,7 +9,7 @@ import serial
 from powermon.commands.command import Command, CommandType
 from powermon.commands.result import Result
 from powermon.dto.portDTO import PortDTO
-from powermon.errors import ConfigError, PowermonWIP
+from powermon.errors import ConfigError
 from powermon.ports.abstractport import AbstractPort
 from powermon.ports.porttype import PortType
 from powermon.protocols import get_protocol_definition
@@ -58,23 +58,21 @@ class SerialPort(AbstractPort):
                 # need to build a command
                 command = self.protocol.get_id_command()
                 for _path in paths:
-                    print(f"checking path: {_path} to see if it matches {identifier}")
+                    log.debug("Multiple paths - checking path: %s to see if it matches %s", _path, identifier)
                     self.path = _path
                     asyncio.run(self.connect())
                     res = asyncio.run(self.send_and_receive(command=command))
                     if not res.is_valid:
-                        log.info("path: %s does not match for identifier: %s", _path, identifier)
+                        log.debug("path: %s does not match for identifier: %s", _path, identifier)
                         continue
                     # print(res.readings[0])
                     # print(res.readings[0].data_value)
                     # print(res.readings[0].data_value == identifier)
                     if res.readings[0].data_value == identifier:
-                        log.info("SUCCESS: path: %s matches for identifier: %s", _path, identifier)
+                        log.debug("SUCCESS: path: %s matches for identifier: %s", _path, identifier)
                         return
-                raise ConfigError(f"none of {paths} match {identifier}")
+                raise ConfigError(f"Multiple paths - none of {paths} match {identifier}")
         # end of multi-path logic
-        
-        # self.error_message = None
 
     def to_dto(self) -> PortDTO:
         dto = PortDTO(type="serial", path=self.path, baud=self.baud, protocol=self.protocol.to_dto())

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -45,7 +45,7 @@ class SerialPort(AbstractPort):
         paths = glob(path)
         path_count = len(paths)
         match path_count:
-            case 10:
+            case 0:
                 log.error("no matching paths found on this system for: %s", path)
                 raise ConfigError(f"no matching paths found on this system for {path}")
             case 1:
@@ -62,14 +62,15 @@ class SerialPort(AbstractPort):
                     self.path = _path
                     asyncio.run(self.connect())
                     res = asyncio.run(self.send_and_receive(command=command))
-                    print(res)
-                    if res.is_valid:
-                        print(res.readings[0])
-                        print(res.readings[0].data_value)
-                        print(res.readings[0].data_value == identifier)
-                        if res.readings[0].data_value == identifier:
-                            log.info("path: %s matches for identifier: %s", _path, identifier)
-                            break
+                    if not res.is_valid:
+                        log.info("path: %s does not match for identifier: %s", _path, identifier)
+                        continue
+                    # print(res.readings[0])
+                    # print(res.readings[0].data_value)
+                    # print(res.readings[0].data_value == identifier)
+                    if res.readings[0].data_value == identifier:
+                        log.info("SUCCESS: path: %s matches for identifier: %s", _path, identifier)
+                        return
                 raise ConfigError(f"none of {paths} match {identifier}")
         # end of multi-path logic
         

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -62,10 +62,10 @@ class SerialPort(AbstractPort):
                     self.path = _path
                     asyncio.run(self.connect())
                     res = asyncio.run(self.send_and_receive(command=command))
-                    print(res)
-                    
-                    # self.send_and_receive()
-                raise PowermonWIP("multiple path resolution is TODO")
+                    if res and res.data_value == identifier:
+                        log.info("path: %s matchs for identifier: %s", _path, identifier)
+                        break
+                raise ConfigError(f"none of {paths} match {identifier}")
         # end of multi-path logic
         
         # self.error_message = None

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -65,8 +65,10 @@ class SerialPort(AbstractPort):
                     print(res)
                     if res.is_valid:
                         print(res.readings[0])
+                        print(res.readings.data_value[0])
+                        print(res.readings[0].data_value == identifier)
                         if res.readings[0].data_value == identifier:
-                            log.info("path: %s matchs for identifier: %s", _path, identifier)
+                            log.info("path: %s matches for identifier: %s", _path, identifier)
                             break
                 raise ConfigError(f"none of {paths} match {identifier}")
         # end of multi-path logic
@@ -162,7 +164,7 @@ class SerialPort(AbstractPort):
                     c = self.serial_port.write(full_command)
                     log.debug("Default serial s&r. Wrote %i bytes", c)
                     self.serial_port.flush()
-                    time.sleep(0.1)  # give serial port time to receive the data
+                    time.sleep(0.3)  # give serial port time to receive the data
                     response_line = self.serial_port.read_until(b"\r")
             log.info("serial response was: %s", response_line)
             # response = self.get_protocol().check_response_and_trim(response_line)

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -62,7 +62,8 @@ class SerialPort(AbstractPort):
                     self.path = _path
                     asyncio.run(self.connect())
                     res = asyncio.run(self.send_and_receive(command=command))
-                    if res and res.data_value == identifier:
+                    print(res)
+                    if res.is_valid and res.data_value == identifier:
                         log.info("path: %s matchs for identifier: %s", _path, identifier)
                         break
                 raise ConfigError(f"none of {paths} match {identifier}")

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -65,7 +65,7 @@ class SerialPort(AbstractPort):
                     print(res)
                     if res.is_valid:
                         print(res.readings[0])
-                        print(res.readings.data_value[0])
+                        print(res.readings[0].data_value)
                         print(res.readings[0].data_value == identifier)
                         if res.readings[0].data_value == identifier:
                             log.info("path: %s matches for identifier: %s", _path, identifier)

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -38,6 +38,8 @@ class SerialPort(AbstractPort):
         self.port_type = PortType.SERIAL
         self.is_protocol_supported()
         self.path = None
+        self.baud = baud
+        self.serial_port = None
         # self.identifier = identifier
         # using glob to determine path(s)
         paths = glob(path)
@@ -65,8 +67,7 @@ class SerialPort(AbstractPort):
                     # self.send_and_receive()
                 raise PowermonWIP("multiple path resolution is TODO")
         # end of multi-path logic
-        self.baud = baud
-        self.serial_port = None
+        
         # self.error_message = None
 
     def to_dto(self) -> PortDTO:

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -43,7 +43,7 @@ class SerialPort(AbstractPort):
         paths = glob(path)
         path_count = len(paths)
         match path_count:
-            case 0:
+            case 10:
                 log.error("no matching paths found on this system for: %s", path)
                 raise ConfigError(f"no matching paths found on this system for {path}")
             case 1:
@@ -53,8 +53,15 @@ class SerialPort(AbstractPort):
                 # more than one valid path - so we need to determine which to use
                 if identifier is None:
                     raise ConfigError("To use wildcard paths an identifier must be specified in the config file for the port")
+                # need to build a command
+                command = self.protocol.get_id_command()
                 for _path in paths:
                     print(f"checking path: {_path} to see if it matches {identifier}")
+                    self.path = _path
+                    res = self.send_and_receive(command=command)
+                    print(res)
+                    
+                    # self.send_and_receive()
                 raise PowermonWIP("multiple path resolution is TODO")
         # end of multi-path logic
         self.baud = baud

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -63,9 +63,11 @@ class SerialPort(AbstractPort):
                     asyncio.run(self.connect())
                     res = asyncio.run(self.send_and_receive(command=command))
                     print(res)
-                    if res.is_valid and res.readings[0].data_value == identifier:
-                        log.info("path: %s matchs for identifier: %s", _path, identifier)
-                        break
+                    if res.is_valid:
+                        print(res.readings[0])
+                        if res.readings[0].data_value == identifier:
+                            log.info("path: %s matchs for identifier: %s", _path, identifier)
+                            break
                 raise ConfigError(f"none of {paths} match {identifier}")
         # end of multi-path logic
         

--- a/powermon/ports/serialport.py
+++ b/powermon/ports/serialport.py
@@ -63,7 +63,7 @@ class SerialPort(AbstractPort):
                     asyncio.run(self.connect())
                     res = asyncio.run(self.send_and_receive(command=command))
                     print(res)
-                    if res.is_valid and res.data_value == identifier:
+                    if res.is_valid and res.readings[0].data_value == identifier:
                         log.info("path: %s matchs for identifier: %s", _path, identifier)
                         break
                 raise ConfigError(f"none of {paths} match {identifier}")

--- a/powermon/ports/usbport.py
+++ b/powermon/ports/usbport.py
@@ -55,7 +55,7 @@ class USBPort(AbstractPort):
                     asyncio.run(self.connect())
                     res = asyncio.run(self.send_and_receive(command=command))
                     if not res.is_valid:
-                        log.debug("path: %s does not match for identifier: %s", _path, identifier)
+                        log.info("path: %s does not match for identifier: %s", _path, identifier)
                         continue
                     if res.readings[0].data_value == identifier:
                         log.info("SUCCESS: path: %s matches for identifier: %s", _path, identifier)

--- a/powermon/ports/usbport.py
+++ b/powermon/ports/usbport.py
@@ -56,11 +56,11 @@ class USBPort(AbstractPort):
                     res = asyncio.run(self.send_and_receive(command=command))
                     if not res.is_valid:
                         log.info("path: %s does not match for identifier: %s", _path, identifier)
+                        asyncio.run(self.disconnect())
                         continue
                     if res.readings[0].data_value == identifier:
                         log.info("SUCCESS: path: %s matches for identifier: %s", _path, identifier)
                         return
-                    asyncio.run(self.disconnect())
                 raise ConfigError(f"Multiple paths - none of {paths} match {identifier}")
         # end of multi-path logic
 

--- a/powermon/ports/usbport.py
+++ b/powermon/ports/usbport.py
@@ -61,6 +61,8 @@ class USBPort(AbstractPort):
                     if res.readings[0].data_value == identifier:
                         log.info("SUCCESS: path: %s matches for identifier: %s", _path, identifier)
                         return
+                    else:
+                        print(res.readings[0].data_value == identifier, res.readings[0].data_value, identifier)
                 raise ConfigError(f"Multiple paths - none of {paths} match {identifier}")
         # end of multi-path logic
 

--- a/powermon/ports/usbport.py
+++ b/powermon/ports/usbport.py
@@ -60,6 +60,7 @@ class USBPort(AbstractPort):
                     if res.readings[0].data_value == identifier:
                         log.info("SUCCESS: path: %s matches for identifier: %s", _path, identifier)
                         return
+                    asyncio.run(self.disconnect())
                 raise ConfigError(f"Multiple paths - none of {paths} match {identifier}")
         # end of multi-path logic
 

--- a/powermon/ports/usbport.py
+++ b/powermon/ports/usbport.py
@@ -58,11 +58,9 @@ class USBPort(AbstractPort):
                         log.info("path: %s does not match for identifier: %s", _path, identifier)
                         asyncio.run(self.disconnect())
                         continue
-                    if res.readings[0].data_value == identifier:
+                    if res.readings[0].data_value == str(identifier):
                         log.info("SUCCESS: path: %s matches for identifier: %s", _path, identifier)
                         return
-                    else:
-                        print(res.readings[0].data_value == identifier, res.readings[0].data_value, identifier)
                 raise ConfigError(f"Multiple paths - none of {paths} match {identifier}")
         # end of multi-path logic
 

--- a/powermon/protocols/abstractprotocol.py
+++ b/powermon/protocols/abstractprotocol.py
@@ -190,6 +190,10 @@ class AbstractProtocol(metaclass=abc.ABCMeta):
                 # check for construct
                 if command_definition.construct is None:
                     raise CommandDefinitionIncorrect("No construct found in command_definition")
+                if command_definition.construct_min_response is None:
+                    raise CommandDefinitionIncorrect("No construct_min_response found in command_definition")
+                if len(response) < command_definition.construct_min_response:
+                    raise InvalidResponse(f"response:{response}, len:{len(response)} too short for parsing (expecting {command_definition.construct_min_response:})")
                 # parse with construct
                 result = command_definition.construct.parse(response)
                 # print(result)

--- a/powermon/protocols/pi30.py
+++ b/powermon/protocols/pi30.py
@@ -673,6 +673,7 @@ class PI30(AbstractProtocol):
         self.add_command_definitions(SETTER_COMMANDS, result_type=ResultType.ACK)
         self.check_definitions_count(expected=45)
         self.add_supported_ports([PortType.SERIAL, PortType.USB])
+        self.id_command = "QID"
 
     def check_crc(self, response: str, command_definition: CommandDefinition = None):
         """ crc check, needs override in protocol """

--- a/powermon/protocols/pi30max.py
+++ b/powermon/protocols/pi30max.py
@@ -868,6 +868,7 @@ class PI30MAX(PI30):
         self.add_command_definitions(SETTER_COMMANDS, result_type=ResultType.ACK)
         self.remove_command_definitions(COMMANDS_TO_REMOVE)
         self.check_definitions_count(expected=67)
+        self.id_command = "QSID"
 
         self.STATUS_COMMANDS = ["QPIGS", "QPIGS2"]
         self.SETTINGS_COMMANDS = ["QPIRI", "QFLAG"]

--- a/powermon/protocols/ved.py
+++ b/powermon/protocols/ved.py
@@ -153,6 +153,7 @@ COMMANDS = {
         "command_code": "1000",
         "result_type": ResultType.CONSTRUCT,
         "construct": battery_capacity_defn,
+        "construct_min_response": 6,
         "reading_definitions": [
             {"index": "command_type", "description": "command type", "reading_type": ReadingType.IGNORE},
             {"index": "command", "description": "command", "reading_type": ReadingType.IGNORE},
@@ -179,6 +180,7 @@ COMMANDS = {
         "command_code": "010A",
         "result_type": ResultType.CONSTRUCT,
         "construct": serial_number_defn,
+        "construct_min_response": 20,
         "reading_definitions": [
             {"index": "command_type", "description": "command type", "reading_type": ReadingType.IGNORE},
             {"index": "command", "description": "command", "reading_type": ReadingType.IGNORE},

--- a/powermon/protocols/ved.py
+++ b/powermon/protocols/ved.py
@@ -3,11 +3,13 @@ import logging
 from struct import unpack
 import construct as cs
 
-from powermon.commands.command import CommandType
+from powermon.commands.command import Command, CommandType
 from powermon.commands.command_definition import CommandDefinition
 from powermon.commands.reading_definition import ReadingType, ResponseType
 from powermon.commands.result import ResultType
+from powermon.commands.trigger import Trigger
 from powermon.errors import CommandError, InvalidCRC, InvalidResponse
+from powermon.outputs import multiple_from_config
 from powermon.ports.porttype import PortType
 from powermon.protocols.abstractprotocol import AbstractProtocol
 from powermon.protocols.helpers import victron_checksum
@@ -212,6 +214,18 @@ class VictronEnergyDirect(AbstractProtocol):
         self.add_command_definitions(COMMANDS)
         self.add_supported_ports([PortType.SERIAL, PortType.USB])
         self.check_definitions_count(expected=3)
+
+    def get_id_command(self) -> Command:
+        """ return the command that generates a unique id for this type of device """
+        command_code = "serial_number"
+        cd = self.get_command_definition(command_code)
+        outputs = multiple_from_config({"type": "screen", "format": "raw"})
+        trigger = Trigger.from_config(None)
+        command = Command(code=command_code, commandtype=cd.command_type, outputs=outputs, trigger=trigger)
+        command.command_definition = cd
+        command.full_command = self.get_full_command(command_code)
+        log.debug(command)
+        return command
 
     def get_full_command(self, command) -> bytes:
         """

--- a/powermon/protocols/ved.py
+++ b/powermon/protocols/ved.py
@@ -1,15 +1,14 @@
 """ protocols / ved.py """
 import logging
 from struct import unpack
+
 import construct as cs
 
-from powermon.commands.command import Command, CommandType
+from powermon.commands.command import CommandType
 from powermon.commands.command_definition import CommandDefinition
 from powermon.commands.reading_definition import ReadingType, ResponseType
 from powermon.commands.result import ResultType
-from powermon.commands.trigger import Trigger
 from powermon.errors import CommandError, InvalidCRC, InvalidResponse
-from powermon.outputs import multiple_from_config
 from powermon.ports.porttype import PortType
 from powermon.protocols.abstractprotocol import AbstractProtocol
 from powermon.protocols.helpers import victron_checksum
@@ -214,18 +213,7 @@ class VictronEnergyDirect(AbstractProtocol):
         self.add_command_definitions(COMMANDS)
         self.add_supported_ports([PortType.SERIAL, PortType.USB])
         self.check_definitions_count(expected=3)
-
-    def get_id_command(self) -> Command:
-        """ return the command that generates a unique id for this type of device """
-        command_code = "serial_number"
-        cd = self.get_command_definition(command_code)
-        outputs = multiple_from_config({"type": "screen", "format": "raw"})
-        trigger = Trigger.from_config(None)
-        command = Command(code=command_code, commandtype=cd.command_type, outputs=outputs, trigger=trigger)
-        command.command_definition = cd
-        command.full_command = self.get_full_command(command_code)
-        log.debug(command)
-        return command
+        self.id_command = "serial_number"
 
     def get_full_command(self, command) -> bytes:
         """
@@ -323,7 +311,7 @@ class VictronEnergyDirect(AbstractProtocol):
                 _ret = response.split(b":")[1][:-3]
                 _ret = _ret.decode()
                 _ret = f'0{_ret}'
-                log.debug(f"bytes.fromhex: {_ret}")
+                log.debug("bytes.fromhex: %s", _ret)
                 _ret = bytes.fromhex(_ret)
             case CommandType.VICTRON_LISTEN:
                 # VEDTEXT response, return the lot

--- a/tests/pmon/config/min.yaml
+++ b/tests/pmon/config/min.yaml
@@ -5,8 +5,9 @@ device:
   model: 8048MAX
   manufacturer: MPP-Solar
   port:
-    type: test
-    # path: /dev/ttyUSB0
+    type: serial
+    path: /dev/ttyUSB*
+    identifier: A123456789
     # response_number: 0
     # mac: 66:66:18:01:09:18
     protocol: VED

--- a/tests/pmon/config/test.yaml
+++ b/tests/pmon/config/test.yaml
@@ -1,0 +1,21 @@
+# test port config
+device:
+  name: Test_Inverter
+  id: A123456789
+  model: 8048MAX
+  manufacturer: MPP-Solar
+  port:
+    type: test
+    identifier: A123456789
+    response_number: 3
+    protocol: DALY
+
+commands:
+- command: SOC
+  outputs:
+  - type: screen
+    format: 
+      type: table
+      draw_lines: True
+      extra_info: True
+loop: once

--- a/tests/pmon/unit/test_command.py
+++ b/tests/pmon/unit/test_command.py
@@ -9,6 +9,7 @@ from powermon.commands.result import ResultType
 from powermon.commands.reading_definition import ReadingType, ResponseType
 from powermon.commands.parameter import ParameterType, ParameterFormat
 
+
 class test_command(unittest.TestCase):
     def test_command_definition_none(self):
         command = Command(code="test", commandtype="test", outputs=[], trigger=None)
@@ -60,5 +61,3 @@ class test_command(unittest.TestCase):
         self.assertEqual(reading.data_unit, "Wh")
         self.assertEqual(reading.data_value, 238800)
         self.assertEqual(reading.data_name, "PV Generated Energy for Day")
-        
-        

--- a/tests/pmon/unit/test_port_serialport.py
+++ b/tests/pmon/unit/test_port_serialport.py
@@ -17,7 +17,7 @@ class TestSerialPort(TestCase):
 
     # Given
     def setUp(self):
-        self.port = SerialPort(path=None, baud=None, protocol=PI30MAX())
+        self.port = SerialPort(path='/dev/tty0', baud=None, protocol=PI30MAX(), identifier=None)
 
     def test_is_connected_when_port_is_open(self):
         """

--- a/tests/pmon/unit/test_protocol_daly.py
+++ b/tests/pmon/unit/test_protocol_daly.py
@@ -1,0 +1,61 @@
+""" tests / pmon / unit / test_protocol_daly.py """
+import unittest
+import construct as cs
+
+from powermon.commands.command_definition import CommandDefinition
+from powermon.commands.result import ResultType
+from powermon.commands.command import CommandType
+from powermon.commands.reading_definition import ReadingType, ResponseType
+from powermon.errors import InvalidResponse
+from powermon.protocols import get_protocol_definition
+
+
+soc_construct = cs.Struct(
+    "start_flag" / cs.Bytes(1),
+    "module_address" / cs.Bytes(1),
+    "command_id" / cs.Bytes(1),
+    "data_length" / cs.Byte,
+    "battery_voltage" / cs.Int16ub,
+    "acquistion_voltage" / cs.Int16ub,
+    "current" / cs.Int16ub,
+    "soc" / cs.Int16ub,
+    "checksum" / cs.Bytes(1)
+)
+
+command_definitions_config = {
+    "name": "SOC",
+    "description": "State of Charge",
+    "help": " -- display the battery state of charge",
+    # "type": "DALY",
+    "command_type": CommandType.SERIAL_READ_UNTIL_DONE,
+    "command_code": "90",
+    "result_type": ResultType.CONSTRUCT,
+    "construct": soc_construct,
+    "construct_min_response": 13,
+    "reading_definitions": [
+        {"index": "start_flag", "description": "start flag", "reading_type": ReadingType.IGNORE, "response_type": ResponseType.HEX_CHAR},
+        {"index": "module_address", "description": "module address", "reading_type": ReadingType.IGNORE, "response_type": ResponseType.HEX_CHAR},
+        {"index": "command_id", "description": "command id", "reading_type": ReadingType.IGNORE, "response_type": ResponseType.HEX_CHAR},
+        {"index": "data_length", "description": "data length", "reading_type": ReadingType.IGNORE},
+        {"index": "battery_voltage", "description": "Battery Bank Voltage", "reading_type": ReadingType.VOLTS, "response_type": ResponseType.TEMPLATE_INT, "format_template": "r/10"},
+        {"index": "acquistion_voltage", "description": "acquistion", "reading_type": ReadingType.VOLTS, "response_type": ResponseType.TEMPLATE_INT, "format_template": "r/10"},
+        {"index": "current", "description": "Current", "reading_type": ReadingType.CURRENT, "response_type": ResponseType.TEMPLATE_INT, "format_template": "(r-30000)/10"},
+        {"index": "soc", "description": "SOC", "reading_type": ReadingType.PERCENTAGE, "response_type": ResponseType.TEMPLATE_INT, "format_template": "r/10"},
+        {"index": "checksum", "description": "checksum", "reading_type": ReadingType.IGNORE, "response_type": ResponseType.HEX_CHAR}]}
+cd = CommandDefinition.from_config(command_definitions_config)
+cd.construct = soc_construct
+cd.construct_min_response = 13
+protocol = get_protocol_definition(protocol="daly")
+
+
+class TestProtocolDaly(unittest.TestCase):
+    """ exercise different functions in DALY protocol """
+
+    def test_check_crc(self):
+        """ test a for correct CRC validation """
+        result = protocol.check_crc(response=b"\x00\x1a:70010007800C6\n", command_definition=cd)
+        self.assertTrue(result)
+
+    def test_construct_short_response(self):
+        """ test for correct failure if response is too short for construct parsing """
+        self.assertRaises(InvalidResponse, protocol.split_response, response=b'', command_definition=cd)

--- a/tests/pmon/unit/test_protocol_jkserial.py
+++ b/tests/pmon/unit/test_protocol_jkserial.py
@@ -56,7 +56,7 @@ class TestProtocolJKSerial(unittest.TestCase):
 
     def test_port_notsupported_usb(self):
         """ test that jkserial protocol is not supported on UsbPort"""
-        self.assertRaises(PowermonProtocolError, USBPort, "path", protocol)
+        self.assertRaises(PowermonProtocolError, USBPort, "path", protocol, "id")
         # self.assertIsInstance(sp, AbstractPort)
 
     def test_port_supported_test(self):

--- a/tests/pmon/unit/test_protocol_jkserial.py
+++ b/tests/pmon/unit/test_protocol_jkserial.py
@@ -51,7 +51,7 @@ class TestProtocolJKSerial(unittest.TestCase):
 
     def test_port_supported_serial(self):
         """ test that jkserial protocol is supported on SerialPort"""
-        _port = SerialPort("path", 9600, protocol)
+        _port = SerialPort("/dev/tty0", 9600, protocol, "id")
         self.assertIsInstance(_port, AbstractPort)
 
     def test_port_notsupported_usb(self):

--- a/tests/pmon/unit/test_protocol_ved.py
+++ b/tests/pmon/unit/test_protocol_ved.py
@@ -28,6 +28,7 @@ command_definitions_config = {
     "command_code": "1000",
     "result_type": ResultType.CONSTRUCT,
     "construct": battery_capacity_defn,
+    "construct_min_response": 6,
     "reading_definitions": [
         {"index": "command_type", "description": "command type", "reading_type": ReadingType.IGNORE},
         {"index": "command", "description": "command", "reading_type": ReadingType.IGNORE},

--- a/tests/pmon/unit/test_resulttype.py
+++ b/tests/pmon/unit/test_resulttype.py
@@ -1,14 +1,15 @@
 """ tests / pmon / unit / test_resulttype.py """
-import struct
+# import struct
 import unittest
 
 import construct as cs
 
-from powermon.commands.result import Result, ResultType
+from powermon.commands.result import ResultType
 from powermon.protocols.abstractprotocol import AbstractProtocol
-from powermon.commands.reading_definition import (ReadingDefinition, ReadingType, ResponseType)
+from powermon.commands.reading_definition import ReadingDefinition, ResponseType
 from powermon.commands.command_definition import CommandDefinition
 from powermon.errors import CommandDefinitionIncorrect
+
 
 class TestResultTypes(unittest.TestCase):
     """ test different result types """
@@ -19,6 +20,7 @@ class TestResultTypes(unittest.TestCase):
         reading_definition = ReadingDefinition.from_config(reading_definition_config, 0)
         command_definition = CommandDefinition(code="CODE", description="description", help_text="", result_type=ResultType.CONSTRUCT, reading_definitions=[reading_definition])
         command_definition.construct = construct
+        command_definition.construct_min_response = 1
         result = AbstractProtocol.split_response(self, response=b"\x0f\x90", command_definition=command_definition)
         expected = [('voltage', 3984)]
         self.assertEqual(result, expected)


### PR DESCRIPTION
Using wildcards eg `/dev/ttyUSB*` for port path and and identifier to allow powermon to try and find the correct path
example yaml
```yaml
port:
    type: serial
    path: /dev/ttyUSB*
    identifier: A123456789
    protocol: VED
```