### PR TITLE
Replace "/" in prometheus metrics

### DIFF
--- a/mppsolar/outputs/prom.py
+++ b/mppsolar/outputs/prom.py
@@ -63,7 +63,7 @@ class prom(baseoutput):
         for key, _values in data.items():
             # remove spaces
             if remove_spaces:
-                key = key.replace(" ", "_")
+                key = key.replace(" ", "_").replace("/","_")
             if not keep_case:
                 # make lowercase
                 key = key.lower()


### PR DESCRIPTION
Prometheus metrics can break if there is a `/` in data point name