### PR TITLE
fix pi17 GPMP0 regex to allow setting to all integers

### DIFF
--- a/mppsolar/protocols/pi17.py
+++ b/mppsolar/protocols/pi17.py
@@ -550,7 +550,7 @@ SETTER_COMMANDS = {
             b"^1\x0b\xc2\r",
             b"^0\x1b\xe3\r",
         ],
-        "regex": "GPMP(0[10][12345]\d\d\d)$",
+        "regex": "GPMP(0[10]\d\d\d\d)$",
     },
     "LON": {
         "name": "LON",


### PR DESCRIPTION
previously the default value of 10000 did not match the regex