### PR TITLE
Support writing prometheus metrics to files

### DIFF
--- a/mppsolar/__init__.py
+++ b/mppsolar/__init__.py
@@ -144,6 +144,14 @@ def main():
         default="http://localhost:9091/metrics/job/pushgateway",
     )
     parser.add_argument(
+        "--prom_output_dir",
+        help=(
+            "Output directory where Prometheus metrics are written as .prom files"
+            "(default: /var/lib/node_exporter)"
+        ),
+        default="/var/lib/node_exporter",
+    )
+    parser.add_argument(
         "-c",
         "--command",
         nargs="?",
@@ -251,6 +259,7 @@ def main():
     keep_case = args.keepcase
     mqtt_topic = args.mqtttopic
     push_url = args.pushurl
+    prom_output_dir = args.prom_output_dir
 
     _commands = []
     # Initialize Daemon
@@ -315,6 +324,7 @@ def main():
             mongo_url = config[section].get("mongo_url", fallback=None)
             mongo_db = config[section].get("mongo_db", fallback=None)
             push_url = config[section].get("push_url", fallback=push_url)
+            prom_output_dir = config[section].get("prom_output_dir", fallback=prom_output_dir)
             mqtt_topic = config[section].get("mqtt_topic", fallback=mqtt_topic)
             #
             device_class = get_device_class(_type)
@@ -333,6 +343,7 @@ def main():
                 mongo_url=mongo_url,
                 mongo_db=mongo_db,
                 push_url=push_url,
+                prom_output_dir=prom_output_dir,
             )
             # build array of commands
             commands = _command.split("#")
@@ -372,6 +383,7 @@ def main():
             mongo_url=mongo_url,
             mongo_db=mongo_db,
             push_url=push_url,
+            prom_output_dir=prom_output_dir,
         )
         #
 
@@ -432,7 +444,7 @@ def main():
                 # eg QDI run, Display Inverter Default Settings
                 log.debug(f"Using output filter: {filter}")
                 op.output(
-                    data=results,
+                    data=results.copy(),
                     tag=_tag,
                     name=_device._name,
                     mqtt_broker=mqtt_broker,
@@ -441,6 +453,7 @@ def main():
                     mongo_url=mongo_url,
                     mongo_db=mongo_db,
                     push_url=push_url,
+                    prom_output_dir=prom_output_dir,
                     # mqtt_port=mqtt_port,
                     # mqtt_user=mqtt_user,
                     # mqtt_pass=mqtt_pass,

--- a/mppsolar/outputs/prom.py
+++ b/mppsolar/outputs/prom.py
@@ -51,7 +51,7 @@ class prom(baseoutput):
             excl_filter = re.compile(excl_filter)
         if name == "unnamed":
             name = "mpp_solar"
-      
+
         # remove raw response
         data.pop("raw_response", None)
         data.pop("_command_description", None)
@@ -63,7 +63,7 @@ class prom(baseoutput):
         for key, _values in data.items():
             # remove spaces
             if remove_spaces:
-                key = key.replace(" ", "_").replace("/","_")
+                key = key.replace(" ", "_").replace("/", "_").replace("-", "")
             if not keep_case:
                 # make lowercase
                 key = key.lower()

--- a/mppsolar/outputs/prom_file.py
+++ b/mppsolar/outputs/prom_file.py
@@ -1,0 +1,25 @@
+import logging
+
+from .prom import prom
+from ..helpers import get_kwargs
+
+log = logging.getLogger("prom")
+
+
+class prom_file(prom):
+    prom_output_dir = ""
+
+    def __str__(self):
+        return "pushes Node exporter Prometheus format to PushGateway"
+
+    def output(self, *args, **kwargs):
+        # We override the method only to get the PushGateway URL from the config
+        self.prom_output_dir = kwargs["prom_output_dir"]
+        self.cmd = get_kwargs(kwargs, "data").get("_command", "").lower()
+
+        return super().output(*args, **kwargs)
+
+    def handle_output(self, content: str) -> None:
+        file_path = f"{self.prom_output_dir.rstrip('/')}/mpp-solar-{self.cmd}.prom"
+        with open(file_path, "w") as f:
+            f.write(content)


### PR DESCRIPTION
Example config file
```
[SETUP]
pause=5
mqtt_broker={{ mqtt_broker }}
mqtt_user={{ mqtt_user }}
mqtt_pass={{ mqtt_pass }}

[inverter1]
port=/dev/hidraw0
protocol=PI18
command=GS#MOD
tag=mpp
outputs=hass_mqtt,prom_file
```
this would result in two files getting written in `/var/lib/node_exporter/` `mpp-solar-gs.prom` & `mpp-solar-mod.prom`. Which can then be picked up by node_exporter and exposed to prometheus.