### PR TITLE
Prom fix to allow complex devvice grouping

### DIFF
--- a/mppsolar/outputs/prom.py
+++ b/mppsolar/outputs/prom.py
@@ -36,7 +36,7 @@ class prom(baseoutput):
             filter = config.get("filter", None)
             excl_filter = config.get("excl_filter", None)
             name = config.get("name", "mpp_solar")
-            dev = config.get("dev", "None")
+            dev = config.get("dev", dev)
         else:
             # get formatting info
             remove_spaces = True
@@ -51,6 +51,10 @@ class prom(baseoutput):
             excl_filter = re.compile(excl_filter)
         if name == "unnamed":
             name = "mpp_solar"
+
+
+        if dev is None:
+            dev = "None"
 
         # remove raw response
         data.pop("raw_response", None)

--- a/mppsolar/outputs/prom_file.py
+++ b/mppsolar/outputs/prom_file.py
@@ -16,10 +16,16 @@ class prom_file(prom):
         # We override the method only to get the PushGateway URL from the config
         self.prom_output_dir = kwargs["prom_output_dir"]
         self.cmd = get_kwargs(kwargs, "data").get("_command", "").lower()
+        self.name = get_kwargs(kwargs, "name")
 
         return super().output(*args, **kwargs)
 
     def handle_output(self, content: str) -> None:
-        file_path = f"{self.prom_output_dir.rstrip('/')}/mpp-solar-{self.cmd}.prom"
+        if self.name != "unnamed":
+            self.filename = "{0}-{1}".format(self.name, self.cmd)
+        else:
+            self.filename = self.cmd
+            
+        file_path = f"{self.prom_output_dir.rstrip('/')}/mpp-solar-{self.filename}.prom"
         with open(file_path, "w") as f:
             f.write(content)


### PR DESCRIPTION
This fixes the naming convention of prometheus file (prom_file) to support config section or implicit setting of name-cmd pairs so that more complex configurations maybe used as well as finished the ability to add device grouping within the configuration or cli.