### PR TITLE
Fix: add cases for rfc2217:// and socket:// before the : catch-all

### DIFF
--- a/mppsolar/inout/__init__.py
+++ b/mppsolar/inout/__init__.py
@@ -46,6 +46,13 @@ def get_port_type(port):
     elif "esp" in port:
         log.debug("port matches esp")
         return PortType.ESP32
+    # pyserial URL schemes — must be checked before the ':' MAC address catch-all
+    elif port.startswith("rfc2217://"):
+        log.debug("port matches rfc2217:// — using serial")
+        return PortType.SERIAL
+    elif port.startswith("socket://"):
+        log.debug("port matches socket:// — using serial")
+        return PortType.SERIAL
     # JKBLE type ports
     elif ":" in port:
         # all mac addresses currently return as JKBLE

--- a/mppsolar/inout/serialio.py
+++ b/mppsolar/inout/serialio.py
@@ -21,7 +21,10 @@ class SerialIO(BaseIO):
             with serial.serial_for_url(self._serial_port, self._serial_baud) as s:
                 log.debug("Executing command via serialio...")
                 s.timeout = 1
-                s.write_timeout = 1
+                try:
+                    s.write_timeout = 1
+                except Exception:
+                    pass  # rfc2217:// and some other backends don't support write_timeout
                 s.flushInput()
                 s.flushOutput()
                 s.write(full_command)


### PR DESCRIPTION
FEAT: Added RFC2217 Serial over IP configuration capability (remote ser2net).